### PR TITLE
Feature: 시설물 검색, 검색 결과 화면

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
+import 'package:annyong/presentation/providers/search_result_provider.dart';
 import 'package:annyong/presentation/router/router.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,14 +13,19 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      theme: ThemeData(
-        scaffoldBackgroundColor: Colors.white,
-        appBarTheme: AppBarTheme(backgroundColor: Colors.white),
-        fontFamily: 'Pretendard',
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => SearchResultProvider()),
+      ],
+      child: MaterialApp.router(
+        theme: ThemeData(
+          scaffoldBackgroundColor: Colors.white,
+          appBarTheme: AppBarTheme(backgroundColor: Colors.white),
+          fontFamily: 'Pretendard',
+        ),
+        title: 'Annyong App',
+        routerConfig: AppRouter.router,
       ),
-      title: 'Annyong App',
-      routerConfig: AppRouter.router,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp.router(
       theme: ThemeData(
         scaffoldBackgroundColor: Colors.white,
+        appBarTheme: AppBarTheme(backgroundColor: Colors.white),
         fontFamily: 'Pretendard',
       ),
       title: 'Annyong App',

--- a/lib/presentation/providers/search_result_provider.dart
+++ b/lib/presentation/providers/search_result_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/foundation.dart';
+
+class SearchResultProvider extends ChangeNotifier {
+  String _searchKeyword = '';
+  String _selectedFloor = '2F';
+
+  String get searchKeyword => _searchKeyword;
+  String get selectedFloor => _selectedFloor;
+
+  void setSearchKeyword(String keyword) {
+    _searchKeyword = keyword;
+    notifyListeners();
+  }
+
+  void setSelectedFloor(String floor) {
+    _selectedFloor = floor;
+    notifyListeners();
+  }
+}
+

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -2,6 +2,7 @@ import 'package:annyong/presentation/ui/bookmark_page.dart';
 import 'package:annyong/presentation/ui/home_page.dart';
 import 'package:annyong/presentation/ui/menu_page.dart';
 import 'package:annyong/presentation/ui/search_page.dart';
+import 'package:annyong/presentation/ui/search_result_page.dart';
 import 'package:annyong/presentation/ui/search_rooms_page.dart';
 import 'package:annyong/presentation/ui/settings_page.dart';
 import 'package:flutter/material.dart';
@@ -50,8 +51,16 @@ class AppRouter {
                       return SearchRoomsPage(searchType: searchType);
                     },
                   ),
+                  GoRoute(
+                    path: "searchResult",
+                    builder: (context, state) {
+                      final searchKeyword = state.extra as String? ?? '';
+                      return SearchResultPage(searchKeyword: searchKeyword);
+                    },
+                  ),
                 ],
               ),
+              // 검색 결과 페이지
             ],
           ),
         ],

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -45,7 +45,10 @@ class AppRouter {
                 routes: [
                   GoRoute(
                     path: "searchRooms",
-                    builder: (context, state) => SearchRoomsPage(),
+                    builder: (context, state) {
+                      final searchType = state.extra as String? ?? '';
+                      return SearchRoomsPage(searchType: searchType);
+                    },
                   ),
                 ],
               ),

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -1,6 +1,8 @@
 import 'package:annyong/presentation/ui/bookmark_page.dart';
 import 'package:annyong/presentation/ui/home_page.dart';
 import 'package:annyong/presentation/ui/menu_page.dart';
+import 'package:annyong/presentation/ui/search_page.dart';
+import 'package:annyong/presentation/ui/search_rooms_page.dart';
 import 'package:annyong/presentation/ui/settings_page.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -21,6 +23,7 @@ class AppRouter {
             path: "/home",
             builder: (context, state) => HomePage(),
             routes: [
+              // 메뉴 관련 페이지
               GoRoute(
                 path: "menu",
                 builder: (context, state) => MenuPage(),
@@ -32,6 +35,17 @@ class AppRouter {
                   GoRoute(
                     path: "settings",
                     builder: (context, state) => SettingsPage(),
+                  ),
+                ],
+              ),
+              // 검색 관련 페이지
+              GoRoute(
+                path: "search",
+                builder: (context, state) => SearchPage(),
+                routes: [
+                  GoRoute(
+                    path: "searchRooms",
+                    builder: (context, state) => SearchRoomsPage(),
                   ),
                 ],
               ),

--- a/lib/presentation/ui/home_page.dart
+++ b/lib/presentation/ui/home_page.dart
@@ -40,7 +40,9 @@ class HomePage extends StatelessWidget {
                       const SizedBox(width: 12),
                       // ------------------시설물 검색 버튼------------------
                       GestureDetector(
-                        onTap: () {},
+                        onTap: () {
+                          context.go('/home/search');
+                        },
                         child: Container(
                           width: 200,
                           height: 50,
@@ -63,7 +65,9 @@ class HomePage extends StatelessWidget {
                       const SizedBox(width: 12),
                       // ------------------길찾기 버튼------------------
                       GestureDetector(
-                        onTap: () {},
+                        onTap: () {
+                          //context.go('/home/search');
+                        },
                         child: Container(
                           width: 80,
                           height: 50,

--- a/lib/presentation/ui/home_page.dart
+++ b/lib/presentation/ui/home_page.dart
@@ -1,14 +1,17 @@
+import 'package:annyong/presentation/providers/search_result_provider.dart';
 import 'package:annyong/presentation/theme/app_colors.dart';
 import 'package:annyong/presentation/widgets/bookmark__button.dart';
 import 'package:annyong/presentation/widgets/floor_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final provider = context.watch<SearchResultProvider>();
     return Scaffold(
       body: SafeArea(
         child: Center(
@@ -144,8 +147,16 @@ class HomePage extends StatelessWidget {
                   right: 0,
                   child: Column(
                     children: [
-                      FloorButton(isSelected: true, floorNumber: 2),
-                      FloorButton(isSelected: false, floorNumber: 1),
+                      FloorButton(
+                        floor: '2F',
+                        onTap: () => provider.setSelectedFloor('2F'),
+                        isSelected: provider.selectedFloor == '2F',
+                      ),
+                      FloorButton(
+                        floor: '1F',
+                        onTap: () => provider.setSelectedFloor('1F'),
+                        isSelected: provider.selectedFloor == '1F',
+                      ),
                     ],
                   ),
                 ),

--- a/lib/presentation/ui/search_page.dart
+++ b/lib/presentation/ui/search_page.dart
@@ -120,7 +120,9 @@ class SearchFacilitiesTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {},
+      onTap: () {
+        context.go('/home/search/searchResult', extra: title);
+      },
       child: Container(
         alignment: Alignment.center,
         width: 112,

--- a/lib/presentation/ui/search_page.dart
+++ b/lib/presentation/ui/search_page.dart
@@ -12,10 +12,11 @@ class SearchPage extends StatelessWidget {
         centerTitle: true,
         title: Text("시설물 검색", style: TextStyle(fontSize: 24)),
         leading: Padding(
-          padding: EdgeInsetsGeometry.symmetric(horizontal: 12),
+          padding: const EdgeInsetsGeometry.symmetric(horizontal: 12),
           child: IconButton(
             onPressed: () => context.pop(),
             icon: Icon(Icons.arrow_back_ios),
+            color: AppColors.text,
           ),
         ),
       ),
@@ -86,7 +87,9 @@ class SearchRoomsTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {},
+      onTap: () {
+        context.push('/home/search/searchRooms', extra: title);
+      },
       child: Container(
         alignment: Alignment.center,
         width: 112,

--- a/lib/presentation/ui/search_page.dart
+++ b/lib/presentation/ui/search_page.dart
@@ -1,0 +1,141 @@
+import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class SearchPage extends StatelessWidget {
+  const SearchPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text("시설물 검색", style: TextStyle(fontSize: 24)),
+        leading: Padding(
+          padding: EdgeInsetsGeometry.symmetric(horizontal: 12),
+          child: IconButton(
+            onPressed: () => context.pop(),
+            icon: Icon(Icons.arrow_back_ios),
+          ),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '공간',
+              style: TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 150,
+              child: GridView(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  childAspectRatio: 1,
+                  mainAxisSpacing: 12,
+                  crossAxisSpacing: 12,
+                ),
+                children: [
+                  SearchRoomsTile(title: '강의실'),
+                  SearchRoomsTile(title: '라운지\n교내 카페'),
+                  SearchRoomsTile(title: '동아리방\n사무실'),
+                ],
+              ),
+            ),
+            Text(
+              '시설물',
+              style: TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+            Flexible(
+              child: GridView(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  childAspectRatio: 1,
+                  mainAxisSpacing: 12,
+                  crossAxisSpacing: 12,
+                ),
+                children: [
+                  SearchFacilitiesTile(title: '엘리베이터\n계단'),
+                  SearchFacilitiesTile(title: '화장실'),
+                  SearchFacilitiesTile(title: '자판기'),
+                  SearchFacilitiesTile(title: '정수기'),
+                  SearchFacilitiesTile(title: '프린트'),
+                  SearchFacilitiesTile(title: 'ATM'),
+                  SearchFacilitiesTile(title: '콘센트'),
+                  SearchFacilitiesTile(title: '소화기'),
+                  SearchFacilitiesTile(title: '제세동기'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SearchRoomsTile extends StatelessWidget {
+  const SearchRoomsTile({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {},
+      child: Container(
+        alignment: Alignment.center,
+        width: 112,
+        height: 112,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(14),
+          color: AppColors.grey200,
+        ),
+        child: Text(
+          title,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: AppColors.text,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class SearchFacilitiesTile extends StatelessWidget {
+  const SearchFacilitiesTile({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {},
+      child: Container(
+        alignment: Alignment.center,
+        width: 112,
+        height: 112,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(14),
+          color: AppColors.grey200,
+        ),
+        child: Text(
+          title,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: AppColors.text,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/ui/search_result_page.dart
+++ b/lib/presentation/ui/search_result_page.dart
@@ -1,0 +1,170 @@
+import 'package:annyong/presentation/providers/search_result_provider.dart';
+import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:annyong/presentation/widgets/floor_button.dart';
+import 'package:annyong/presentation/widgets/search_result_item.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+class SearchResultPage extends StatelessWidget {
+  final String searchKeyword;
+
+  const SearchResultPage({super.key, required this.searchKeyword});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<SearchResultProvider>();
+
+    // 페이지 진입 시 searchKeyword 설정
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      provider.setSearchKeyword(searchKeyword);
+    });
+
+    // 임시 데이터 - 나중에 실제 데이터로 교체
+    final List<Map<String, String>> searchResults = [
+      {'title': '장소 이름 1', 'description': '장소와 관련된 설명 등'},
+      {'title': '장소 이름 2', 'description': '장소와 관련된 설명 등'},
+      {'title': '장소 이름 3', 'description': '장소와 관련된 설명 등'},
+    ];
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Stack(
+        children: [
+          // 지도 영역 (상단 60%)
+          Column(
+            children: [
+              Expanded(
+                flex: 6,
+                child: Container(
+                  color: Colors.white,
+                  child: Stack(
+                    children: [
+                      // 지도 플레이스홀더 (실제 지도는 나중에 추가)
+                      Container(color: Colors.white),
+                      // 뒤로가기 버튼
+                      SafeArea(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: IconButton(
+                            onPressed: () => context.pop(),
+                            icon: Icon(
+                              Icons.arrow_back_ios,
+                              color: AppColors.text,
+                              size: 24,
+                            ),
+                          ),
+                        ),
+                      ),
+                      // 사용자 위치 표시 아이콘
+                      Center(
+                        child: Container(
+                          margin: const EdgeInsets.only(right: 120, bottom: 80),
+                          child: Container(
+                            width: 48,
+                            height: 48,
+                            decoration: BoxDecoration(
+                              color: AppColors.primary,
+                              shape: BoxShape.circle,
+                              border: Border.all(color: Colors.white, width: 3),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.2),
+                                  blurRadius: 8,
+                                  offset: const Offset(0, 2),
+                                ),
+                              ],
+                            ),
+                            child: Icon(
+                              Icons.navigation,
+                              color: Colors.white,
+                              size: 24,
+                            ),
+                          ),
+                        ),
+                      ),
+                      // 층 선택 버튼 (오른쪽 하단, 하단 패널 위에 배치)
+                      Positioned(
+                        bottom: MediaQuery.of(context).size.height * 0.4 + 20,
+                        right: 20,
+                        child: Column(
+                          children: [
+                            FloorButton(
+                              floor: '2F',
+                              isSelected: provider.selectedFloor == '2F',
+                              onTap: () {
+                                provider.setSelectedFloor('2F');
+                              },
+                            ),
+                            const SizedBox(height: 8),
+                            FloorButton(
+                              floor: '1F',
+                              isSelected: provider.selectedFloor == '1F',
+                              onTap: () {
+                                provider.setSelectedFloor('1F');
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          // 검색 결과 패널 (하단 40%)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Container(
+              height: MediaQuery.of(context).size.height * 0.4,
+              decoration: BoxDecoration(
+                color: AppColors.grey200,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(24),
+                  topRight: Radius.circular(24),
+                ),
+              ),
+              child: Column(
+                children: [
+                  // 패널 드래그 핸들
+                  Container(
+                    margin: const EdgeInsets.only(top: 12),
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: AppColors.grey400,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  // 검색 결과 리스트
+                  Expanded(
+                    child: ListView.builder(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 16,
+                      ),
+                      itemCount: searchResults.length,
+                      itemBuilder: (context, index) {
+                        final result = searchResults[index];
+                        return SearchResultItem(
+                          title: result['title']!,
+                          description: result['description']!,
+                          onSelect: () {
+                            // 선택 동작 (나중에 구현)
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/ui/search_rooms_page.dart
+++ b/lib/presentation/ui/search_rooms_page.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SearchRoomsPage extends StatelessWidget {
+  const SearchRoomsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    throw UnimplementedError();
+  }
+}

--- a/lib/presentation/ui/search_rooms_page.dart
+++ b/lib/presentation/ui/search_rooms_page.dart
@@ -232,10 +232,9 @@ class _SearchRoomsPageState extends State<SearchRoomsPage> {
                           itemBuilder: (context, index) {
                             final classroom = classrooms[index];
                             final isSelected = selectedClassroom == classroom;
-                            return CategoryItem(
+                            return CategoryItemRooms(
                               name: classroom,
                               isSelected: isSelected,
-                              onTap: () => _onClassroomSelected(classroom),
                             );
                           },
                         ),

--- a/lib/presentation/ui/search_rooms_page.dart
+++ b/lib/presentation/ui/search_rooms_page.dart
@@ -1,11 +1,250 @@
+import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:annyong/presentation/widgets/search_rooms_page_widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
-class SearchRoomsPage extends StatelessWidget {
-  const SearchRoomsPage({super.key});
+class SearchRoomsPage extends StatefulWidget {
+  final String searchType;
+
+  const SearchRoomsPage({super.key, required this.searchType});
+
+  @override
+  State<SearchRoomsPage> createState() => _SearchRoomsPageState();
+}
+
+class _SearchRoomsPageState extends State<SearchRoomsPage> {
+  String? selectedBuilding;
+  String? selectedFloor;
+  String? selectedClassroom;
+
+  // 임시 데이터 - 나중에 실제 데이터로 교체
+  final List<String> buildings = [
+    '하이테크',
+    '5호관(동)',
+    '5호관(서)',
+    '5호관(남)',
+    '5호관(북)',
+  ];
+
+  // 층 목록은 건물 선택 후 표시
+  List<String> floors = [];
+  // 강의실 번호 목록은 층 선택 후 표시
+  List<String> classrooms = [];
+
+  @override
+  void initState() {
+    super.initState();
+    // 기본값 설정 (UI 확인용)
+    selectedBuilding = '하이테크';
+    floors = []; // 하이테크에는 층 목록이 없음
+    selectedFloor = null;
+    classrooms = [];
+    selectedClassroom = null;
+  }
+
+  void _onBuildingSelected(String building) {
+    setState(() {
+      selectedBuilding = building;
+      selectedFloor = null;
+      selectedClassroom = null;
+      // 건물 선택 시 해당 건물의 층 목록 로드
+      if (building == '5호관(남)') {
+        floors = ['B1', '1F', '2F', '3F', '4F', '5F', '6F'];
+      } else {
+        floors = [];
+      }
+      classrooms = [];
+    });
+  }
+
+  void _onFloorSelected(String floor) {
+    setState(() {
+      selectedFloor = floor;
+      selectedClassroom = null;
+      // 층 선택 시 해당 층의 강의실 목록 로드 (임시 데이터)
+      if (selectedBuilding == '5호관(남)' && floor == '5F') {
+        classrooms = [
+          '5S501',
+          '5S503',
+          '5S505',
+          '5S509',
+          '5S517',
+          '5S518',
+          '5S521',
+          '5S531',
+          '5S532',
+          '5S533',
+          '5S534',
+          '5S535',
+        ];
+      } else {
+        classrooms = [];
+      }
+    });
+  }
+
+  void _onClassroomSelected(String classroom) {
+    setState(() {
+      selectedClassroom = classroom;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
-    throw UnimplementedError();
+    return Scaffold(
+      appBar: AppBar(
+        leading: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: IconButton(
+            onPressed: () => context.pop(),
+            icon: Icon(Icons.arrow_back_ios, color: AppColors.text),
+          ),
+        ),
+        title: Row(
+          children: [
+            Expanded(
+              child: Container(
+                height: 48,
+                decoration: BoxDecoration(
+                  color: AppColors.grey200,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                alignment: Alignment.centerLeft,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      '강의실 번호를 입력하세요!',
+                      style: TextStyle(
+                        fontSize: 15,
+                        color: AppColors.grey400,
+                        fontFamily: 'Pretendard',
+                      ),
+                    ),
+                    Icon(Icons.search_rounded, color: AppColors.text, size: 24),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(width: 20),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: 12),
+          // -------------------선택 요소 표시용 헤더-------------------
+          Container(
+            decoration: BoxDecoration(
+              color: AppColors.grey200,
+              border: Border(
+                bottom: BorderSide(color: AppColors.grey300, width: 1),
+              ),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Stack(
+                    children: [
+                      CategoryBox(categoryName: '건물'),
+                      if (selectedBuilding != null && selectedFloor == null)
+                        SelectedCategoryFlag(),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Stack(
+                    children: [
+                      CategoryBox(categoryName: '층'),
+                      if (selectedFloor != null && selectedClassroom == null)
+                        SelectedCategoryFlag(),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Stack(
+                    children: [
+                      CategoryBox(categoryName: '강의실 번호'),
+                      if (selectedClassroom != null) SelectedCategoryFlag(),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // -------------------세부 정보 선택 창-------------------
+          Expanded(
+            child: Row(
+              children: [
+                // -------------------건물 컬럼-------------------
+                Expanded(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border(
+                        right: BorderSide(color: AppColors.grey300, width: 1),
+                      ),
+                    ),
+                    child: ListView.builder(
+                      itemCount: buildings.length,
+                      itemBuilder: (context, index) {
+                        final building = buildings[index];
+                        final isSelected = selectedBuilding == building;
+                        return CategoryItem(
+                          name: building,
+                          isSelected: isSelected,
+                          onTap: () => _onBuildingSelected(building),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+                // -------------------층 컬럼-------------------
+                Expanded(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border(
+                        right: BorderSide(color: AppColors.grey300, width: 1),
+                      ),
+                    ),
+                    child: selectedBuilding == null
+                        ? const SizedBox()
+                        : ListView.builder(
+                            itemCount: floors.length,
+                            itemBuilder: (context, index) {
+                              final floor = floors[index];
+                              final isSelected = selectedFloor == floor;
+                              return CategoryItem(
+                                name: floor,
+                                isSelected: isSelected,
+                                onTap: () => _onFloorSelected(floor),
+                              );
+                            },
+                          ),
+                  ),
+                ),
+                // -------------------강의실 번호 컬럼-------------------
+                Expanded(
+                  child: selectedFloor == null
+                      ? const SizedBox()
+                      : ListView.builder(
+                          itemCount: classrooms.length,
+                          itemBuilder: (context, index) {
+                            final classroom = classrooms[index];
+                            final isSelected = selectedClassroom == classroom;
+                            return CategoryItem(
+                              name: classroom,
+                              isSelected: isSelected,
+                              onTap: () => _onClassroomSelected(classroom),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/presentation/widgets/floor_button.dart
+++ b/lib/presentation/widgets/floor_button.dart
@@ -1,36 +1,42 @@
 import 'package:annyong/presentation/theme/app_colors.dart';
 import 'package:flutter/material.dart';
 
-class FloorButton extends StatefulWidget {
+class FloorButton extends StatelessWidget {
+  final String floor;
+  final bool isSelected;
+  final VoidCallback onTap;
+
   const FloorButton({
     super.key,
+    required this.floor,
     required this.isSelected,
-    required this.floorNumber,
+    required this.onTap,
   });
 
-  final bool isSelected;
-  final int floorNumber;
-
-  @override
-  State<FloorButton> createState() => _FloorButtonState();
-}
-
-class _FloorButtonState extends State<FloorButton> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: EdgeInsets.only(top: 4),
-      alignment: Alignment.center,
-      width: 47,
-      height: 47,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: widget.isSelected ? AppColors.primary : AppColors.grey200,
-      ),
-      child: Text(
-        "${widget.floorNumber}F",
-        style: TextStyle(
-          color: widget.isSelected ? Colors.white : AppColors.text,
+    return GestureDetector(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 8),
+        child: Container(
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            color: isSelected ? AppColors.primary : AppColors.grey200,
+            shape: BoxShape.circle,
+          ),
+          child: Center(
+            child: Text(
+              floor,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: isSelected ? Colors.white : AppColors.text,
+                fontFamily: 'Pretendard',
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/search_result_item.dart
+++ b/lib/presentation/widgets/search_result_item.dart
@@ -1,0 +1,76 @@
+import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class SearchResultItem extends StatelessWidget {
+  final String title;
+  final String description;
+  final VoidCallback onSelect;
+
+  const SearchResultItem({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 장소 이름
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.text,
+                    fontFamily: 'Pretendard',
+                  ),
+                ),
+                const SizedBox(height: 4),
+                // 장소 설명
+                Text(
+                  description,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w400,
+                    color: AppColors.text,
+                    fontFamily: 'Pretendard',
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          GestureDetector(
+            onTap: onSelect,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              decoration: BoxDecoration(
+                color: AppColors.primary,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                '선택',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                  fontFamily: 'Pretendard',
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/search_rooms_page_widgets.dart
+++ b/lib/presentation/widgets/search_rooms_page_widgets.dart
@@ -1,0 +1,85 @@
+import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class SelectedCategoryFlag extends StatelessWidget {
+  const SelectedCategoryFlag({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: Container(
+          height: 3,
+          width: 30,
+          decoration: BoxDecoration(
+            color: AppColors.text,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class CategoryBox extends StatelessWidget {
+  const CategoryBox({super.key, required this.categoryName});
+
+  final String categoryName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.center,
+      height: 50,
+      child: Text(
+        categoryName,
+        style: TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+          color: AppColors.text,
+          fontFamily: 'Pretendard',
+        ),
+      ),
+    );
+  }
+}
+
+class CategoryItem extends StatelessWidget {
+  final String name;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const CategoryItem({
+    super.key,
+    required this.name,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        color: isSelected ? AppColors.primary : Colors.white,
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
+        child: Text(
+          name,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w400,
+            color: isSelected ? Colors.white : AppColors.text,
+            fontFamily: 'Pretendard',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/search_rooms_page_widgets.dart
+++ b/lib/presentation/widgets/search_rooms_page_widgets.dart
@@ -1,5 +1,6 @@
 import 'package:annyong/presentation/theme/app_colors.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SelectedCategoryFlag extends StatelessWidget {
   const SelectedCategoryFlag({super.key});
@@ -66,6 +67,40 @@ class CategoryItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
+      child: Container(
+        color: isSelected ? AppColors.primary : Colors.white,
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
+        child: Text(
+          name,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w400,
+            color: isSelected ? Colors.white : AppColors.text,
+            fontFamily: 'Pretendard',
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class CategoryItemRooms extends StatelessWidget {
+  final String name;
+  final bool isSelected;
+
+  const CategoryItemRooms({
+    super.key,
+    required this.name,
+    required this.isSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        context.go('/home/search/searchResult', extra: name);
+      },
       child: Container(
         color: isSelected ? AppColors.primary : Colors.white,
         padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 12),


### PR DESCRIPTION
## 📝작업 내용

> 시설물 검색 타일 UI 구현
검색 결과 화면 구현
아직 데이터 연결은 되지 않은 상태로 UI만 그려둔 상태
시설물 검색 타일에서 건물->층->호수 순으로 선택할 수 있음

## 메모

> 시설물 검색 화면에서 호수를 선택하면 바로 검색 결과로 넘어가도록 구현되어있음
여기에서 터치를 한번 더 해야 넘어가게 할지, 검색 버튼을 누르게 해야 할지 고민