### PR TITLE
Fix: 보폭 측정 UI/UX 수정

### DIFF
--- a/lib/domain/repository/poi_repository.dart
+++ b/lib/domain/repository/poi_repository.dart
@@ -91,6 +91,10 @@ class PoiRepository {
       final rawWay = rawEdge['way'] as String?;
       final wayType = WayTypeParser.from(rawWay);
 
+      if (length == 0) {
+        debugPrint("[Warning] 길이가 0인 엣지 발견: $v1Id <-> $v2Id (좌표가 동일함)");
+      }
+
       if (v1Id == null ||
           v2Id == null ||
           v1Id < 0 ||

--- a/lib/domain/usecases/calibration_service.dart
+++ b/lib/domain/usecases/calibration_service.dart
@@ -87,61 +87,72 @@ class CalibrationService {
       return null;
     }
 
-    // 찾은 경로들 중 가장 긴 경로 선택
+    // 이전 커밋까지는 찾은 경로들 중 가장 긴 경로만 확인 후 유효하지 않다면(연결된 POI없음) null을 반환해서 예외 처리에 취약했음
+    // 그래서 차순위 후보 경로들도 순회하며 유효한지(POI가 있는지) 확인하여 예외 처리 보강
     availablePaths.sort((a, b) => b.$2.compareTo(a.$2)); // 내림차순 정렬
-    final (bestVertex, bestDistance) = availablePaths.first;
 
-    // 측정 불가 조건 체크
-    if (bestDistance < minRoundTripDistance) {
+    for (final (bestVertex, bestDistance) in availablePaths) {
       debugPrint(
-        "[FindRoute] 실패: 최장 경로($bestDistance m)가 최소 기준($minRoundTripDistance m)보다 짧습니다.",
+        "[FindRoute] 후보 경로 확인 중: 거리 $bestDistance m, 도착 Vertex ${bestVertex.id}",
       );
-      return null;
-    }
 
-    // 마지막 Vertex에 연결된 POI 찾기
-    final List<Poi> destinationPois = await _poiRepo.getPoisByVertexId(
-      bestVertex.id,
-    );
-
-    if (destinationPois.isEmpty) {
-      debugPrint(
-        "[FindRoute] 실패: 도착 지점(Vertex ${bestVertex.id})에 연결된 POI가 없습니다.",
-      );
-      return null;
-    }
-
-    // 가장 가까운 POI 선택 (Vertex와의 거리가 가장 가까운 것)
-    Poi destinationPoi = destinationPois.first;
-    double minDistance = _poiRepo.getStraightLineDistance(
-      destinationPoi,
-      bestVertex,
-    );
-    for (final poi in destinationPois) {
-      final distance = _poiRepo.getStraightLineDistance(poi, bestVertex);
-      if (distance < minDistance) {
-        minDistance = distance;
-        destinationPoi = poi;
+      // 1. 측정 불가 거리 조건 체크 (너무 짧으면 패스)
+      if (bestDistance < minRoundTripDistance) {
+        debugPrint("   pass: 거리가 너무 짧음 ($bestDistance m)");
+        continue;
       }
+
+      // 2. 도착 Vertex에 연결된 POI가 있는지 확인
+      final List<Poi> destinationPois = await _poiRepo.getPoisByVertexId(
+        bestVertex.id,
+      );
+
+      if (destinationPois.isEmpty) {
+        debugPrint("   pass: 도착 지점(Vertex ${bestVertex.id})에 연결된 POI가 없음");
+        continue; // 이 경로를 포기하고 다음 경로(차선책)로 넘어감
+      }
+
+      // 3. 유효한 경로를 찾았으므로 도착지 설정 로직 진행
+      // 가장 가까운 POI 선택 (Vertex와의 거리가 가장 가까운 것)
+      Poi destinationPoi = destinationPois.first;
+      double minDistance = _poiRepo.getStraightLineDistance(
+        destinationPoi,
+        bestVertex,
+      );
+
+      for (final poi in destinationPois) {
+        final distance = _poiRepo.getStraightLineDistance(poi, bestVertex);
+        if (distance < minDistance) {
+          minDistance = distance;
+          destinationPoi = poi;
+        }
+      }
+
+      // 편도/왕복 모드 및 총 거리 결정
+      final bool isOneWay = bestDistance >= minOneWayDistance;
+
+      final double totalDistance = isOneWay
+          ? bestDistance // 5.6m 이상 (편도)
+          : bestDistance * 2.0; // 1m~5.6m (왕복)
+
+      final String mode = isOneWay ? "one-way" : "round-trip";
+
+      debugPrint(
+        "[FindRoute] 최종 성공: 도착지 ${destinationPoi.name} (거리: $totalDistance, 모드: $mode)",
+      );
+
+      // 찾았으면 바로 반환
+      return CalibrationRoute(
+        startPoi: startPoi,
+        destinationPoi: destinationPoi,
+        totalDistance: totalDistance,
+        mode: mode,
+      );
     }
 
-    // 편도/왕복 모드 및 총 거리 결정
-    final bool isOneWay = bestDistance >= minOneWayDistance;
-
-    final double totalDistance = isOneWay
-        ? bestDistance // 5.6m 이상 (편도)
-        : bestDistance * 2.0; // 1m~5.6m (왕복)
-
-    final String mode = isOneWay ? "one-way" : "round-trip";
-
-    // 결정된 거리, 모드 반환
-    debugPrint("[FindRoute] 성공: 경로 발견 (${totalDistance}m, $mode)");
-    return CalibrationRoute(
-      startPoi: startPoi,
-      destinationPoi: destinationPoi,
-      totalDistance: totalDistance,
-      mode: mode,
-    );
+    // 반복문이 끝날 때까지 return이 안 되었다면 최종 실패로 간주
+    debugPrint("[FindRoute] 실패: 모든 후보 경로가 유효하지 않습니다 (POI 없음 등).");
+    return null;
   }
 
   /// 한쪽 방향으로 "직선"이 끝날 때까지 탐색하는 헬퍼 함수

--- a/lib/domain/usecases/calibration_service.dart
+++ b/lib/domain/usecases/calibration_service.dart
@@ -2,6 +2,7 @@ import 'package:annyong/domain/entity/calibration_route.dart';
 import 'package:annyong/domain/entity/graph_models.dart';
 import 'package:annyong/domain/entity/poi.dart';
 import 'package:annyong/domain/repository/poi_repository.dart';
+import 'package:flutter/foundation.dart';
 
 /// 보폭 측정 서비스
 /// [PoiRepository]에 의존하여 원본 POI 데이터를 가져오고,
@@ -29,6 +30,7 @@ class CalibrationService {
 
     // 1. 시작 POI에 연결된 "시작 정점(Vertex)"을 가져옴
     if (startPoi.vertexId == null) {
+      debugPrint("[FindRoute] 실패: 시작 POI(${startPoi.name})에 vertexId가 없습니다.");
       return null;
     }
 
@@ -36,6 +38,9 @@ class CalibrationService {
       startPoi.vertexId!,
     );
     if (startVertex == null) {
+      debugPrint(
+        "[FindRoute] 실패: Vertex ID(${startPoi.vertexId})에 해당하는 정점 데이터를 찾을 수 없습니다.",
+      );
       return null;
     }
 
@@ -46,6 +51,10 @@ class CalibrationService {
     // 시작 정점에 연결된 모든 엣지(이웃)를 탐색 시작
     final List<Edge> startEdges = await _poiRepo.getEdgesForVertex(
       startVertex.id,
+    );
+
+    debugPrint(
+      "[FindRoute] 탐색 시작: Vertex ${startVertex.id}의 연결된 엣지 수: ${startEdges.length}개",
     );
 
     // 양쪽 2개의 이웃 방향(각 엣지 방향)으로 "직선 경로"를 찾음
@@ -63,6 +72,10 @@ class CalibrationService {
         idealDistance: idealDistance,
       );
 
+      debugPrint(
+        "[FindRoute] 경로 탐색 결과: 거리 $distance m, 도착 Vertex ${endVertex?.id}",
+      );
+
       if (endVertex != null) {
         availablePaths.add((endVertex, distance));
       } else {}
@@ -70,6 +83,7 @@ class CalibrationService {
 
     // 유효한 직선 경로가 아예 없는 경우
     if (availablePaths.isEmpty) {
+      debugPrint("[FindRoute] 실패: 유효한 직선 경로를 찾지 못했습니다.");
       return null;
     }
 
@@ -79,6 +93,9 @@ class CalibrationService {
 
     // 측정 불가 조건 체크
     if (bestDistance < minRoundTripDistance) {
+      debugPrint(
+        "[FindRoute] 실패: 최장 경로($bestDistance m)가 최소 기준($minRoundTripDistance m)보다 짧습니다.",
+      );
       return null;
     }
 
@@ -88,6 +105,9 @@ class CalibrationService {
     );
 
     if (destinationPois.isEmpty) {
+      debugPrint(
+        "[FindRoute] 실패: 도착 지점(Vertex ${bestVertex.id})에 연결된 POI가 없습니다.",
+      );
       return null;
     }
 
@@ -115,6 +135,7 @@ class CalibrationService {
     final String mode = isOneWay ? "one-way" : "round-trip";
 
     // 결정된 거리, 모드 반환
+    debugPrint("[FindRoute] 성공: 경로 발견 (${totalDistance}m, $mode)");
     return CalibrationRoute(
       startPoi: startPoi,
       destinationPoi: destinationPoi,
@@ -140,8 +161,19 @@ class CalibrationService {
     double accDist = accumulatedDistance;
     Vertex? lastStraightVertex;
 
+    // 무한 루프에 빠지는 것을 막기 위해 최대 1000번의 깊이까지만 허용
+    int safetyCounter = 0;
+    const int maxIterations = 1000;
+
     // 직선 경로가 끊길 때까지 while 루프
     while (true) {
+      if (++safetyCounter > maxIterations) {
+        debugPrint(
+          "[Warning] _traceStraightPath: 무한 루프 감지로 인해 강제 종료됨(VertexID: $cId)",
+        );
+        break;
+      }
+
       final currentVertex = await _poiRepo.getVertexById(cId);
       if (currentVertex == null) {
         break; // 맵 데이터 오류

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' as math;
 import 'package:annyong/domain/entity/calibration_route.dart';
 import 'package:annyong/domain/entity/poi.dart';
 import 'package:annyong/domain/repository/poi_repository.dart';
@@ -75,85 +76,59 @@ class _MeasurePageState extends State<MeasurePage> {
 
   // 지도 초기 위치 설정 (출발지와 목적지 중점이 화면 중앙에 오도록)
   void _initializeMapPosition(Size containerSize) {
-    if (_isMapInitialized || _route == null) return;
+    if (_isMapInitialized ||
+        _route == null ||
+        containerSize.width <= 0 ||
+        containerSize.height <= 0)
+      return;
 
-    // 1. 출발지와 목적지 좌표 (원본 이미지 기준)
-    // 2x 이미지 기준 좌표라고 가정 (POI 좌표계와 일치하는지 확인 필요)
-    // MapUtilFunctions.getImagePath에서 '2x'를 호출하므로 2x 이미지 사용
-    // HomePage 로직에 따르면 1x 이미지 기준으로 POI 좌표가 설정되어 있을 수 있음
-    // 하지만 path_result_page에서는 0.19 곱해서 쓰고 있음.
-    // 여기서는 InteractiveViewer 내부의 Image가 BoxFit.contain으로 들어감.
+    final buildingName = _getBuildingName(_route!.startPoi.buildingId);
+    final floorString = '${_route!.startPoi.floor}F';
 
-    // 2x 이미지 원본 크기
+    // 기존에 '2x'로 되어 있어서 좌표 계산 배율이 틀어졌던 것이기 때문에
+    // 마커 로직과 동일하게 '1x' 기준으로 원본 크기를 가져오도록 변경
     final originalSize = MapUtilFunctions.getImageOriginalSize(
-      _getBuildingName(_route!.startPoi.buildingId),
-      '${_route!.startPoi.floor}F',
-      '2x',
+      buildingName,
+      floorString,
+      '1x',
     );
 
-    // 2x 이미지 기준으로 POI 좌표 변환 (필요하다면)
-    // 여기서는 POI 좌표(xCoord, yCoord)가 어떤 해상도 기준인지 불명확하지만
-    // HomePage에서는 1x 기준으로 계산하여 사용.
-    // path_result_page에서는 xCoord * 0.19로 사용.
+    if (originalSize.width == 0 || originalSize.height == 0) return;
 
-    // 안전하게 가기 위해:
-    // InteractiveViewer의 child인 Image가 BoxFit.contain으로 렌더링될 때의 실제 크기 구하기
     final displayedSize = MapUtilFunctions.getDisplayedImageSize(
       containerSize,
       originalSize,
     );
 
-    // 축소 비율 (원본 대비 화면 표시 비율)
-    final scaleX = displayedSize.width / originalSize.width;
-    final scaleY = displayedSize.height / originalSize.height;
+    // 2. 스케일 계산 (BoxFit.contain이므로 가로/세로 비율 중 맞는 것 하나만 쓰면 됨)
+    // displayedSize는 이미 비율이 맞춰진 크기이므로 width 기준으로 계산
+    final scale = displayedSize.width / originalSize.width;
 
-    // 화면상에서의 출발/도착 좌표 (Zoom 1.0일 때)
-    final p1 = Offset(
-      _route!.startPoi.xCoord * scaleX,
-      _route!.startPoi.yCoord * scaleY,
+    // 3. 여백(Offset) 계산
+    final offsetX = (containerSize.width - displayedSize.width) / 2;
+    final offsetY = (containerSize.height - displayedSize.height) / 2;
+
+    // 4. 출발지 좌표를 화면상 절대 좌표로 변환
+    final startX = _route!.startPoi.xCoord * scale + offsetX;
+    final startY = _route!.startPoi.yCoord * scale + offsetY;
+
+    // 5. 목적지 좌표 계산 (줌 레벨 결정을 위해)
+    final endX = _route!.destinationPoi.xCoord * scale + offsetX;
+    final endY = _route!.destinationPoi.yCoord * scale + offsetY;
+
+    // 6. 줌 레벨 계산 (화면 너비의 40% 정도가 되도록)
+    final dist = math.sqrt(
+      math.pow(startX - endX, 2) + math.pow(startY - endY, 2),
     );
-    final p2 = Offset(
-      _route!.destinationPoi.xCoord * scaleX,
-      _route!.destinationPoi.yCoord * scaleY,
-    );
+    double targetScale = (dist > 0) ? (containerSize.width * 0.4 / dist) : 3.0;
+    targetScale = targetScale.clamp(2.5, 6.0);
 
-    // 중점 (여기서는 시작 지점을 중심으로 설정)
-    // 기존: final center = Offset((p1.dx + p2.dx) / 2, (p1.dy + p2.dy) / 2);
-    final center = p1; // 시작 지점을 중심으로 설정
+    // 7. 중앙 정렬을 위한 이동량(Translation) 계산
+    // 화면 중앙 - (출발지 * 줌배율)
+    final tx = (containerSize.width / 2) - (startX * targetScale);
+    final ty = (containerSize.height / 2) - (startY * targetScale);
 
-    // 두 점 사이 거리
-    double dist = (p1 - p2).distance;
-
-    // 목표 스케일: 두 점 사이 거리가 화면 너비의 약 60% 정도 되도록
-    // (너무 꽉 차면 마커가 잘릴 수 있으므로 여유 있게)
-    // 만약 거리가 너무 가깝다면 최대 스케일 제한
-    double targetScale = containerSize.width * 0.6 / dist;
-
-    // 최소/최대 스케일 보정
-    if (targetScale < 2.0) targetScale = 2.0;
-    if (targetScale > 5.0) targetScale = 5.0;
-
-    // 중앙 정렬을 위한 이동(Translation)
-    // 화면 중앙 - (중점 * 스케일)
-    // 오프셋 보정값 추가 (사용자가 직접 조정 가능)
-    const double offsetXCorrection = -50.0; // x축 보정 (왼쪽으로 이동)
-    const double offsetYCorrection = -50.0; // y축 보정 (위로 이동)
-
-    // tx, ty 계산 시 스케일을 고려하여 center에 곱하는 것이 맞음.
-    // (containerWidth/2) - (centerX * scale) => 중심점을 화면 중앙으로.
-    // 여기에 보정값을 더함.
-    // 하지만 InteractiveViewer에 alignment: Alignment.topLeft를 주었으므로,
-    // (0,0) 기준으로 이동해야 함.
-
-    final tx =
-        containerSize.width / 2 - center.dx * targetScale + offsetXCorrection;
-    final ty =
-        containerSize.height / 2 - center.dy * targetScale + offsetYCorrection;
-
-    // 만약 tx, ty가 양수라면(화면 중앙보다 왼쪽/위쪽 여백이 생김), 0으로 제한하여 빈 공간 최소화 (선택 사항)
-    // 하지만 여기서는 특정 지점을 중앙에 놓는 것이 목표이므로 제한하지 않음.
-
-    // 매트릭스 설정 (scale -> translate 순서 주의)
+    // 8. 매트릭스 적용
     final matrix = Matrix4.identity()
       ..translate(tx, ty)
       ..scale(targetScale);
@@ -161,10 +136,7 @@ class _MeasurePageState extends State<MeasurePage> {
     _transformationController.value = matrix;
     _isMapInitialized = true;
 
-    // 상태 업데이트하여 마커 위치 재계산 유도
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) setState(() {});
-    });
+    if (mounted) setState(() {});
   }
 
   Future<void> _requestPermissionAndInit() async {

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -128,6 +128,10 @@ class _MeasurePageState extends State<MeasurePage> {
 
   Future<void> _findRoute() async {
     try {
+      debugPrint("----------- [_findRoute Start] ----------- ");
+      debugPrint(
+        "경로 탐색 시작: Start POI = ${widget.startPoi?.name} (ID: ${widget.startPoi?.id})",
+      );
       final route = await _calibrationService.findTargetRoute(widget.startPoi!);
       setState(() {
         _route = route;
@@ -137,11 +141,15 @@ class _MeasurePageState extends State<MeasurePage> {
         }
       });
     } catch (e, stackTrace) {
+      debugPrint("[Error] 경로 탐색 중 치명적 에러 발생: $e");
+      debugPrint(" -- 스택 트레이스: $stackTrace"); // 에러 파일 위치 디버깅용
+
       setState(() {
         _isLoading = false;
         _errorMessage = "경로 탐색 중 오류가 발생했습니다: $e";
       });
     }
+    debugPrint("----------- [_findRoute End] ----------- ");
   }
 
   void _onArrived() {

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -25,6 +25,9 @@ class _MeasurePageState extends State<MeasurePage> {
     PoiRepository(),
   );
 
+  // widget.startPoi 대신 내부 상태로 관리하여 재선택 시 업데이트 가능하게 함
+  Poi? _targetPoi;
+
   CalibrationRoute? _route;
   bool _isLoading = true;
   String? _errorMessage;
@@ -37,6 +40,9 @@ class _MeasurePageState extends State<MeasurePage> {
   @override
   void initState() {
     super.initState();
+    // 초기 타겟 설정
+    _targetPoi = widget.startPoi;
+
     _requestPermissionAndInit();
     if (widget.startPoi != null) {
       _findRoute();
@@ -127,12 +133,17 @@ class _MeasurePageState extends State<MeasurePage> {
   }
 
   Future<void> _findRoute() async {
+    // _targetPoi가 없으면 실행하지 않음
+    if (_targetPoi == null) return;
+
     try {
       debugPrint("----------- [_findRoute Start] ----------- ");
       debugPrint(
         "경로 탐색 시작: Start POI = ${widget.startPoi?.name} (ID: ${widget.startPoi?.id})",
       );
-      final route = await _calibrationService.findTargetRoute(widget.startPoi!);
+
+      // widget.startPoi 대신 _targetPoi 사용
+      final route = await _calibrationService.findTargetRoute(_targetPoi!);
       setState(() {
         _route = route;
         _isLoading = false;
@@ -152,6 +163,16 @@ class _MeasurePageState extends State<MeasurePage> {
       });
     }
     debugPrint("----------- [_findRoute End] ----------- ");
+  }
+
+  Future<void> _goToResultPage(double strideLength) async {
+    // 결과 페이지로 이동하고, 사용자가 '확인'을 눌러서 pop될 때까지 대기
+    await context.push("/measure/measureResult", extra: strideLength);
+
+    // 결과 페이지가 닫히면(측정 완료), 홈으로 이동
+    if (mounted) {
+      context.go("/home");
+    }
   }
 
   void _onArrived() {
@@ -270,10 +291,10 @@ class _MeasurePageState extends State<MeasurePage> {
                   // 버튼을 아래로 밀어내기 위해 하단 여백 채우기
                   const Spacer(),
 
-                  // 선택지 제공 버: 기본값(0.7m) 설정
+                  // 선택지 제공 버튼: 기본값(0.7m) 설정
                   GestureDetector(
                     onTap: () {
-                      context.push("/measure/measureResult", extra: 0.7);
+                      _goToResultPage(0.7);
                     },
                     child: Container(
                       width: double.infinity,
@@ -322,12 +343,15 @@ class _MeasurePageState extends State<MeasurePage> {
                           extra: {"returnResult": true},
                         );
 
-                        // 새로운 POI가 선택되었다면 해당 POI로 측정 페이지 갱신(교체)
+                        // 선택된 POI가 있으면 상태 업데이트 및 재탐색
                         if (selectedPoi != null && mounted) {
-                          context.pushReplacement(
-                            "/measure",
-                            extra: selectedPoi,
-                          );
+                          setState(() {
+                            _targetPoi = selectedPoi;
+                            _isLoading = true; // 로딩 표시
+                            _errorMessage = null; // 에러 초기화
+                            _route = null; // 기존 경로 초기화
+                          });
+                          _findRoute(); // 재탐색 실행
                         }
                       }
                     },

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -137,7 +137,9 @@ class _MeasurePageState extends State<MeasurePage> {
         _route = route;
         _isLoading = false;
         if (route == null) {
-          _errorMessage = "측정 가능한 경로를 찾을 수 없습니다.\n콘솔 로그를 확인해주세요.";
+          // 측정 불가용 UX 화면을 보여주기 위해 _errorMessage를 명시적으로 비워둠
+          // _errorMessage = "측정 가능한 경로를 찾을 수 없습니다.\n콘솔 로그를 확인해주세요.";
+          _errorMessage = null;
         }
       });
     } catch (e, stackTrace) {
@@ -210,7 +212,139 @@ class _MeasurePageState extends State<MeasurePage> {
               ),
             )
           : _route == null
-          ? const Center(child: Text("경로를 찾을 수 없습니다."))
+          // -------------------- [예외처리용 화면] --------------------
+          ? Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  // 상단 실패 아이콘 (정상 화면과 위치 통일)
+                  Expanded(
+                    flex: 2,
+                    child: Center(
+                      child: Container(
+                        padding: const EdgeInsets.all(40),
+                        width: 140,
+                        height: 140,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: AppColors.grey200,
+                        ),
+                        child: Icon(
+                          Icons.straighten_outlined,
+                          size: 48,
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  // 설명 문구 (정상 화면의 경로 정보와 비슷한 위치)
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    margin: const EdgeInsets.symmetric(vertical: 16),
+                    child: Column(
+                      children: [
+                        const Text(
+                          "직선 경로를 찾기 어려워요",
+                          style: TextStyle(
+                            fontSize: 22,
+                            fontWeight: FontWeight.bold,
+                            color: AppColors.text,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          "선택하신 '${widget.startPoi?.name ?? '위치'}' 주변에는\n도착지로 삼을만한 시설물이 부족합니다.\n다른 장소를 선택하거나 기본값을 사용해주세요.",
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 16,
+                            color: Colors.grey[600],
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  // 버튼을 아래로 밀어내기 위해 하단 여백 채우기
+                  const Spacer(),
+
+                  // 선택지 제공 버: 기본값(0.7m) 설정
+                  GestureDetector(
+                    onTap: () {
+                      context.push("/measure/measureResult", extra: 0.7);
+                    },
+                    child: Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.symmetric(vertical: 18),
+                      decoration: BoxDecoration(
+                        color: AppColors.primary,
+                        borderRadius: BorderRadius.circular(40), // 둥근 모서리 통일
+                        boxShadow: [
+                          BoxShadow(
+                            color: AppColors.primary.withOpacity(0.3),
+                            blurRadius: 10,
+                            offset: const Offset(0, 4),
+                          ),
+                        ],
+                      ),
+                      child: const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            "기본 보폭(70cm)으로 설정",
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          SizedBox(width: 8),
+                          Icon(
+                            Icons.arrow_forward,
+                            color: Colors.white,
+                            size: 20,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+
+                  // 재시도 옵션 (다른 출발지 선택)
+                  TextButton(
+                    onPressed: () async {
+                      if (mounted) {
+                        // POI 선택 페이지로 이동하여 결과를 기다림
+                        final selectedPoi = await context.push<Poi>(
+                          "/measureSelectPoi",
+                          extra: {"returnResult": true},
+                        );
+
+                        // 새로운 POI가 선택되었다면 해당 POI로 측정 페이지 갱신(교체)
+                        if (selectedPoi != null && mounted) {
+                          context.pushReplacement(
+                            "/measure",
+                            extra: selectedPoi,
+                          );
+                        }
+                      }
+                    },
+                    child: Text(
+                      "다른 출발지 선택하기",
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Colors.grey[600],
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 40), // 하단 여백
+                ],
+              ),
+            )
+          // -------------------- [정상 보폭 측정용 화면] --------------------
           : Padding(
               padding: const EdgeInsets.all(24.0),
               child: Column(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import flutter_blue_plus_darwin
-import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterBluePlusPlugin.register(with: registry.registrar(forPlugin: "FlutterBluePlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

* 사용자가 고른 출발지가 보폭 측정 출발지로 적합하지 않다면 기존의 에러 문구를 띄우는 대신 기본 보폭 선택/다른 출발지 선택을 할 수 있도록 예외 처리 화면 구현
* 보폭 측정 화면에 띄울 지도의 중앙에 출발지가 위치할 수 있도록 스케일 계산 오류 수정

### 스크린샷 (선택)
<img width="200" height="400" src="https://github.com/user-attachments/assets/7258a134-a79d-4a48-a975-8ff838f1a6cc"/>
<img width="200" height="400" src="https://github.com/user-attachments/assets/3535c771-ff96-4ee0-99a2-59235ca312d0"/>


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

기존 지도는 여백이랑 스케일 계산이 안맞아서 오류가 났던 것 같습니다! X/Y 여백을 계산하고, 마커 로직과 동일하게 1x 배율 기준으로 한 다음 계산된 이동량만큼 이동시켰습니다.