### PR TITLE
Design: 길찾기 결과, 안내 화면 UI 수정

### DIFF
--- a/lib/domain/usecases/beacon_scan_service.dart
+++ b/lib/domain/usecases/beacon_scan_service.dart
@@ -52,7 +52,7 @@ class BeaconScanService {
   static const double _kalmanQ = 0.3;
 
   // 1m 기준 RSSI (TxPower)
-  static const int _rssiAtOneMeter = -56;
+  //static const int _rssiAtOneMeter = -56;
 
   // 히스테리시스 경계 (진입/이탈)
   static const double _incomingCriterion = -68.0;

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -291,6 +291,11 @@ class AppRouter {
                       final Poi start = extra['start'] as Poi;
                       final Poi end = extra['end'] as Poi;
 
+                      final List<int>? preCalculatedPath =
+                          extra['preCalculatedPath'] as List<int>?;
+                      final double? preCalculatedCost =
+                          extra['preCalculatedCost'] as double?;
+
                       return PathNaviPage(
                         start: start,
                         end: end,
@@ -298,6 +303,8 @@ class AppRouter {
                             (extra['waypoints'] as List<dynamic>?)
                                 ?.cast<Poi>() ??
                             [],
+                        preCalculatedPath: preCalculatedPath,
+                        preCalculatedCost: preCalculatedCost,
                       );
                     },
                   ),

--- a/lib/presentation/ui/measure/measure_notice_page.dart
+++ b/lib/presentation/ui/measure/measure_notice_page.dart
@@ -154,7 +154,7 @@ class _MeasureNoticePageState extends State<MeasureNoticePage> {
                                         .getPoisByIds(nearPoiIds);
                                   }
 
-                                  if (!mounted) return;
+                                  if (!context.mounted) return;
                                   // 3. 페이지 이동
                                   final selectedPoi = await context.push<Poi>(
                                     "/measureSelectPoi",
@@ -171,7 +171,7 @@ class _MeasureNoticePageState extends State<MeasureNoticePage> {
                                   }
                                 } catch (e) {
                                   // 에러 발생 시 기존 방식대로 진행 (인접 POI 없음)
-                                  if (mounted) {
+                                  if (context.mounted) {
                                     final selectedPoi = await context.push<Poi>(
                                       "/measureSelectPoi",
                                       extra: {

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -79,8 +79,9 @@ class _MeasurePageState extends State<MeasurePage> {
     if (_isMapInitialized ||
         _route == null ||
         containerSize.width <= 0 ||
-        containerSize.height <= 0)
+        containerSize.height <= 0) {
       return;
+    }
 
     final buildingName = _getBuildingName(_route!.startPoi.buildingId);
     final floorString = '${_route!.startPoi.floor}F';

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart' as math64;
+import 'package:annyong/presentation/util/get_building_name.dart';
 import 'package:annyong/domain/entity/calibration_route.dart';
 import 'package:annyong/domain/entity/poi.dart';
 import 'package:annyong/domain/repository/poi_repository.dart';
@@ -84,7 +85,7 @@ class _MeasurePageState extends State<MeasurePage> {
       return;
     }
 
-    final buildingName = _getBuildingName(_route!.startPoi.buildingId);
+    final buildingName = getBuildingName(_route!.startPoi.buildingId);
     final floorString = '${_route!.startPoi.floor}F';
 
     // 기존에 '2x'로 되어 있어서 좌표 계산 배율이 틀어졌던 것이기 때문에
@@ -276,18 +277,6 @@ class _MeasurePageState extends State<MeasurePage> {
 
     // 결과 페이지로 이동
     context.push("/measure/measureResult", extra: strideLength);
-  }
-
-  String _getBuildingName(int buildingId) {
-    switch (buildingId) {
-      case 1:
-      case 2:
-        return '5호관';
-      case 3:
-        return '하이테크관';
-      default:
-        return '5호관';
-    }
   }
 
   @override
@@ -523,7 +512,7 @@ class _MeasurePageState extends State<MeasurePage> {
                   // --------------------지도 영역--------------------
                   Builder(
                     builder: (context) {
-                      final buildingName = _getBuildingName(
+                      final buildingName = getBuildingName(
                         _route!.startPoi.buildingId,
                       );
                       final floorString = '${_route!.startPoi.floor}F';

--- a/lib/presentation/ui/measure/measure_page.dart
+++ b/lib/presentation/ui/measure/measure_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;
+import 'package:vector_math/vector_math_64.dart' as math64;
 import 'package:annyong/domain/entity/calibration_route.dart';
 import 'package:annyong/domain/entity/poi.dart';
 import 'package:annyong/domain/repository/poi_repository.dart';
@@ -131,7 +132,7 @@ class _MeasurePageState extends State<MeasurePage> {
 
     // 8. 매트릭스 적용
     final matrix = Matrix4.identity()
-      ..translate(tx, ty)
+      ..scaleByVector3(math64.Vector3(tx, ty, 0))
       ..scale(targetScale);
 
     _transformationController.value = matrix;

--- a/lib/presentation/ui/path/path_navi_page.dart
+++ b/lib/presentation/ui/path/path_navi_page.dart
@@ -12,6 +12,7 @@ import 'package:annyong/presentation/viewmodels/navigation_view_model.dart';
 import 'package:annyong/presentation/util/map_util_funtions.dart';
 import 'package:annyong/presentation/theme/app_colors.dart';
 import 'package:annyong/presentation/ui/path/path_result_page.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:vector_math/vector_math_64.dart' as math64;
 import 'package:annyong/presentation/widgets/home_page/floor_button.dart';
 import 'package:go_router/go_router.dart';
@@ -152,6 +153,104 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
       }
     });
     super.dispose();
+  }
+
+  /// POI 마커를 조건에 맞게 생성하는 헬퍼 메서드
+  Widget _buildPoiMarker({
+    required Poi poi,
+    required String type, // 'departure', 'destination', 'waypoint'
+    required double scaleX,
+    required double scaleY,
+    required double imageOffsetX,
+    required double imageOffsetY,
+  }) {
+    // 아이콘 및 색상 결정
+    String iconPath;
+    String label;
+
+    if (type == 'departure') {
+      iconPath = 'assets/icons/svg/departure_marker.svg';
+      label = '출발지';
+    } else if (type == 'destination') {
+      iconPath = 'assets/icons/svg/destination_marker.svg';
+      label = '목적지';
+    } else {
+      iconPath = 'assets/icons/svg/stopover_marker.svg';
+      label = '경유지';
+    }
+
+    // 좌표 변환
+    final localX = poi.xCoord * scaleX + imageOffsetX;
+    final localY = poi.yCoord * scaleY + imageOffsetY;
+
+    final currentMatrix = _transformationController.value;
+    final screenX =
+        currentMatrix.storage[0] * localX +
+        currentMatrix.storage[4] * localY +
+        currentMatrix.storage[12];
+    final screenY =
+        currentMatrix.storage[1] * localX +
+        currentMatrix.storage[5] * localY +
+        currentMatrix.storage[13];
+
+    // 줌 레벨에 따른 라벨 표시 여부 (예: 2배 이상일 때 표시)
+    final currentZoom = currentMatrix.getMaxScaleOnAxis();
+    final bool showLabel = currentZoom >= 2.0;
+    const double iconSize = 35.0;
+
+    return Positioned(
+      left: screenX - (iconSize / 2),
+      top: screenY - (iconSize / 2),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 마커 아이콘
+          Container(
+            width: iconSize,
+            height: iconSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.2), // alpha 수정
+                  blurRadius: 6,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: SvgPicture.asset(iconPath),
+          ),
+          // 라벨 (선택적 표시)
+          if (showLabel)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Stack(
+                children: [
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      foreground: Paint()
+                        ..style = PaintingStyle.stroke
+                        ..strokeWidth = 3
+                        ..color = Colors.white,
+                    ),
+                  ),
+                  Text(
+                    label,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.text,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
   }
 
   // 초기 위치로 지도 이동
@@ -378,6 +477,19 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                     child: LayoutBuilder(
                       builder: (context, constraints) {
                         final containerSize = constraints.biggest;
+
+                        // 1. 현재 보고 있는 지도의 건물 ID와 층수 계산
+                        final int currentMapBuildingId =
+                            MapUtilFunctions.getBuildingId(_currentBuilding);
+                        final int currentMapFloorNum =
+                            MapUtilFunctions.getFloorNumber(_currentFloor);
+
+                        // 현재 보고 있는 지도의 건물 ID와 층수
+                        final int currentBuildingId =
+                            MapUtilFunctions.getBuildingId(_currentBuilding);
+                        final int currentFloorNum =
+                            MapUtilFunctions.getFloorNumber(_currentFloor);
+
                         // path_result_page에서는 '1x'를 기준으로 계산했음. 동일하게 맞춤
                         final calcOriginalSize =
                             MapUtilFunctions.getImageOriginalSize(
@@ -499,6 +611,12 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                             // 사용자 위치 마커 (InteractiveViewer 좌표 변환 적용)
                             navigationState.when(
                               data: (state) {
+                                // 만약 사용자의 현재층/건물이 보고 있는 지도 층/건물과 다르다면 숨김
+                                if (state.buildingId != currentMapBuildingId ||
+                                    state.floor != currentMapFloorNum) {
+                                  return const SizedBox.shrink();
+                                }
+
                                 double currentX = state.x;
                                 double currentY = state.y;
                                 int currentFloor = state.floor;
@@ -586,52 +704,46 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                               error: (_, __) => const SizedBox.shrink(),
                             ),
 
-                            // 도착지 마커
-                            if (widget.end.floor == widget.start.floor)
-                              Builder(
-                                builder: (context) {
-                                  final localX =
-                                      widget.end.xCoord * scaleX + imageOffsetX;
-                                  final localY =
-                                      widget.end.yCoord * scaleY + imageOffsetY;
+                            // 마커가 현재 보고있는 지도의 층/건물과 일치할 때만 랜더링
+                            // 출발지 마커
+                            if (widget.start.buildingId ==
+                                    currentMapBuildingId &&
+                                widget.start.floor == currentMapFloorNum)
+                              _buildPoiMarker(
+                                poi: widget.start,
+                                type: 'departure',
+                                scaleX: scaleX,
+                                scaleY: scaleY,
+                                imageOffsetX: imageOffsetX,
+                                imageOffsetY: imageOffsetY,
+                              ),
 
-                                  final currentMatrix =
-                                      _transformationController.value;
-                                  final screenX =
-                                      currentMatrix.storage[0] * localX +
-                                      currentMatrix.storage[4] * localY +
-                                      currentMatrix.storage[12];
-                                  final screenY =
-                                      currentMatrix.storage[1] * localX +
-                                      currentMatrix.storage[5] * localY +
-                                      currentMatrix.storage[13];
+                            // 경유지 마커들
+                            ...widget.waypoints.map((waypoint) {
+                              if (waypoint.buildingId == currentMapBuildingId &&
+                                  waypoint.floor == currentMapFloorNum) {
+                                return _buildPoiMarker(
+                                  poi: waypoint,
+                                  type: 'waypoint',
+                                  scaleX: scaleX,
+                                  scaleY: scaleY,
+                                  imageOffsetX: imageOffsetX,
+                                  imageOffsetY: imageOffsetY,
+                                );
+                              }
+                              return const SizedBox.shrink();
+                            }),
 
-                                  return Positioned(
-                                    left: screenX - 12,
-                                    top: screenY - 24,
-                                    child: Container(
-                                      padding: const EdgeInsets.all(4),
-                                      decoration: BoxDecoration(
-                                        color: Colors.white,
-                                        shape: BoxShape.circle,
-                                        boxShadow: [
-                                          BoxShadow(
-                                            color: Colors.black.withValues(
-                                              alpha: 0.3,
-                                            ),
-                                            blurRadius: 8,
-                                            offset: const Offset(0, 2),
-                                          ),
-                                        ],
-                                      ),
-                                      child: Icon(
-                                        Icons.location_on,
-                                        color: Colors.red,
-                                        size: 24,
-                                      ),
-                                    ),
-                                  );
-                                },
+                            // 목적지 마커
+                            if (widget.end.buildingId == currentMapBuildingId &&
+                                widget.end.floor == currentMapFloorNum)
+                              _buildPoiMarker(
+                                poi: widget.end,
+                                type: 'destination',
+                                scaleX: scaleX,
+                                scaleY: scaleY,
+                                imageOffsetX: imageOffsetX,
+                                imageOffsetY: imageOffsetY,
                               ),
 
                             // 상단 상태 정보 (CountSteps)

--- a/lib/presentation/ui/path/path_navi_page.dart
+++ b/lib/presentation/ui/path/path_navi_page.dart
@@ -14,6 +14,7 @@ import 'package:annyong/presentation/theme/app_colors.dart';
 import 'package:annyong/presentation/ui/path/path_result_page.dart';
 import 'package:vector_math/vector_math_64.dart' as math64;
 import 'package:annyong/presentation/widgets/home_page/floor_button.dart';
+import 'package:go_router/go_router.dart';
 
 class PathNaviPage extends ConsumerStatefulWidget {
   final Poi start;
@@ -725,6 +726,42 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                     ), // LayoutBuilder
                   ), // Container
                 ), // Expanded
+                // 하단 버튼 영역
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withAlpha(5),
+                        blurRadius: 10,
+                        offset: const Offset(0, -4),
+                      ),
+                    ],
+                  ),
+                  child: SizedBox(
+                    height: 56,
+                    child: ElevatedButton(
+                      onPressed: () => context.go('/home'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.primary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        elevation: 0,
+                      ),
+                      child: const Text(
+                        '안내 종료',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ); // Column
           },

--- a/lib/presentation/ui/path/path_navi_page.dart
+++ b/lib/presentation/ui/path/path_navi_page.dart
@@ -608,6 +608,48 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                               ),
                             ),
 
+                            // 마커가 현재 보고있는 지도의 층/건물과 일치할 때만 랜더링
+                            // 출발지 마커
+                            if (widget.start.buildingId ==
+                                    currentMapBuildingId &&
+                                widget.start.floor == currentMapFloorNum)
+                              _buildPoiMarker(
+                                poi: widget.start,
+                                type: 'departure',
+                                scaleX: scaleX,
+                                scaleY: scaleY,
+                                imageOffsetX: imageOffsetX,
+                                imageOffsetY: imageOffsetY,
+                              ),
+
+                            // 경유지 마커들
+                            ...widget.waypoints.map((waypoint) {
+                              if (waypoint.buildingId == currentMapBuildingId &&
+                                  waypoint.floor == currentMapFloorNum) {
+                                return _buildPoiMarker(
+                                  poi: waypoint,
+                                  type: 'waypoint',
+                                  scaleX: scaleX,
+                                  scaleY: scaleY,
+                                  imageOffsetX: imageOffsetX,
+                                  imageOffsetY: imageOffsetY,
+                                );
+                              }
+                              return const SizedBox.shrink();
+                            }),
+
+                            // 목적지 마커
+                            if (widget.end.buildingId == currentMapBuildingId &&
+                                widget.end.floor == currentMapFloorNum)
+                              _buildPoiMarker(
+                                poi: widget.end,
+                                type: 'destination',
+                                scaleX: scaleX,
+                                scaleY: scaleY,
+                                imageOffsetX: imageOffsetX,
+                                imageOffsetY: imageOffsetY,
+                              ),
+
                             // 사용자 위치 마커 (InteractiveViewer 좌표 변환 적용)
                             navigationState.when(
                               data: (state) {
@@ -703,48 +745,6 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                               loading: () => const SizedBox.shrink(),
                               error: (_, __) => const SizedBox.shrink(),
                             ),
-
-                            // 마커가 현재 보고있는 지도의 층/건물과 일치할 때만 랜더링
-                            // 출발지 마커
-                            if (widget.start.buildingId ==
-                                    currentMapBuildingId &&
-                                widget.start.floor == currentMapFloorNum)
-                              _buildPoiMarker(
-                                poi: widget.start,
-                                type: 'departure',
-                                scaleX: scaleX,
-                                scaleY: scaleY,
-                                imageOffsetX: imageOffsetX,
-                                imageOffsetY: imageOffsetY,
-                              ),
-
-                            // 경유지 마커들
-                            ...widget.waypoints.map((waypoint) {
-                              if (waypoint.buildingId == currentMapBuildingId &&
-                                  waypoint.floor == currentMapFloorNum) {
-                                return _buildPoiMarker(
-                                  poi: waypoint,
-                                  type: 'waypoint',
-                                  scaleX: scaleX,
-                                  scaleY: scaleY,
-                                  imageOffsetX: imageOffsetX,
-                                  imageOffsetY: imageOffsetY,
-                                );
-                              }
-                              return const SizedBox.shrink();
-                            }),
-
-                            // 목적지 마커
-                            if (widget.end.buildingId == currentMapBuildingId &&
-                                widget.end.floor == currentMapFloorNum)
-                              _buildPoiMarker(
-                                poi: widget.end,
-                                type: 'destination',
-                                scaleX: scaleX,
-                                scaleY: scaleY,
-                                imageOffsetX: imageOffsetX,
-                                imageOffsetY: imageOffsetY,
-                              ),
 
                             // 상단 상태 정보 (CountSteps)
                             CountSteps(navigationState: navigationState),

--- a/lib/presentation/ui/path/path_navi_page.dart
+++ b/lib/presentation/ui/path/path_navi_page.dart
@@ -4,6 +4,7 @@ import 'package:annyong/domain/usecases/path_finder.dart';
 import 'package:annyong/presentation/widgets/path_page/cost_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:annyong/presentation/util/get_building_name.dart';
 import 'package:annyong/domain/entity/poi.dart';
 import 'package:annyong/presentation/providers/path_finder_provider.dart';
 import 'package:annyong/domain/usecases/path_description_builder.dart';
@@ -12,6 +13,7 @@ import 'package:annyong/presentation/util/map_util_funtions.dart';
 import 'package:annyong/presentation/theme/app_colors.dart';
 import 'package:annyong/presentation/ui/path/path_result_page.dart';
 import 'package:vector_math/vector_math_64.dart' as math64;
+import 'package:annyong/presentation/widgets/home_page/floor_button.dart';
 
 class PathNaviPage extends ConsumerStatefulWidget {
   final Poi start;
@@ -69,7 +71,9 @@ class _RippleMarkerState extends State<RippleMarker>
               height: 60 * _controller.value,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: AppColors.primary.withOpacity((1 - _controller.value)),
+                color: AppColors.primary.withAlpha(
+                  ((1 - _controller.value) * 100).toInt(),
+                ),
               ),
             ),
           ),
@@ -90,15 +94,23 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
   // 경로 탐색 결과 캐싱
   PathResult? _cachedPathResult;
 
+  // 현재 보고 있는 건물과 층 상태
+  late String _currentBuilding;
+  late String _currentFloor;
+
   @override
   void initState() {
     super.initState();
+    // 초기 상태 설정
+    _currentBuilding = getBuildingName(widget.start.buildingId);
+    _currentFloor = '${widget.start.floor}F';
+
     // 페이지 진입 시 길 안내 시작
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final navigationNotifier = ref.read(navigationViewModelProvider.notifier);
-      // 출발 POI로 초기 위치 설정
-      navigationNotifier.setInitialPositionFromPoi(widget.start);
-    });
+    // WidgetsBinding.instance.addPostFrameCallback((_) {
+    //   final navigationNotifier = ref.read(navigationViewModelProvider.notifier);
+    //   // 출발 POI로 초기 위치 설정
+    //   navigationNotifier.setInitialPositionFromPoi(widget.start);
+    // });
 
     _mapAnimationController = AnimationController(
       vsync: this,
@@ -135,7 +147,7 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
     super.dispose();
   }
 
-  // 초기 위치로 지도 이동 애니메이션
+  // 초기 위치로 지도 이동
   void _animateToStart(
     Size containerSize,
     Size displayedImageSize,
@@ -160,7 +172,6 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
     final targetY = widget.start.yCoord * scaleY + imageOffsetY;
 
     // 5. 화면 중앙에 위치시키기 위한 Translation 계산
-    // 화면 중앙 - (타겟 좌표 * 줌)
     final translateX = (containerSize.width / 2) - (targetX * targetZoom);
     final translateY = (containerSize.height / 2) - (targetY * targetZoom);
 
@@ -169,7 +180,7 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
       ..translateByVector3(math64.Vector3(translateX, translateY, 0))
       ..scale(targetZoom);
 
-    // 7. 애니메이션 실행
+    // 7. 애니메이션
     _mapAnimation =
         Matrix4Tween(
           begin: _transformationController.value,
@@ -185,17 +196,28 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
     _isMapInitialized = true;
   }
 
-  /// buildingId를 건물 이름으로 변환
-  String _getBuildingName(int buildingId) {
-    switch (buildingId) {
-      case 1:
-      case 2:
-        return '5호관';
-      case 3:
-        return '하이테크관';
-      default:
-        return '5호관';
-    }
+  // 건물 전환
+  void _cycleBuildings(Set<String> involvedBuildings) {
+    if (involvedBuildings.isEmpty) return;
+
+    setState(() {
+      final buildingList = involvedBuildings.toList();
+      final currentIndex = buildingList.indexOf(_currentBuilding);
+      final nextIndex = (currentIndex + 1) % buildingList.length;
+
+      _currentBuilding = buildingList[nextIndex];
+      _currentFloor = '1F';
+      _transformationController.value = Matrix4.identity();
+      // 건물 전환 시 애니메이션 초기화 (필요시)
+      _isMapInitialized = false;
+    });
+  }
+
+  // 층 전환
+  void _changeFloor(String floor) {
+    setState(() {
+      _currentFloor = floor;
+    });
   }
 
   @override
@@ -227,23 +249,38 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
             ),
           ),
           data: (pathFinder) {
-            // 캐싱된 결과가 있으면 재사용, 없으면 새로 계산
             if (_cachedPathResult == null) {
-              // 방문해야 할 모든 지점의 Vertex ID를 순서대로 리스트화
-              // 유효하지 않은 것은 -1로 대체
               final List<int> visitOrder = [
                 widget.start.vertexId ?? -1,
                 ...widget.waypoints.map((e) => e.vertexId ?? -1),
                 widget.end.vertexId ?? -1,
               ];
 
-              // 유효하지 않은 정점이 있을 때 예외 처리
               if (visitOrder.contains(-1)) {
                 return const Center(child: Text("유효하지 않은 위치 정보가 있습니다."));
               }
 
               // 경유지 포함하여 경로 탐색
               _cachedPathResult = pathFinder.findPathWithWaypoints(visitOrder);
+
+              // 경로 시작 지점(Vertex)으로 초기 사용자 위치 설정
+              final calculatedPath = _cachedPathResult;
+              if (calculatedPath != null && calculatedPath.path.isNotEmpty) {
+                final startVertexId = calculatedPath.path.first;
+                final startVertex = pathFinder.vertices[startVertexId];
+
+                if (startVertex != null) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    ref
+                        .read(navigationViewModelProvider.notifier)
+                        .setInitialPosition(
+                          x: startVertex.x,
+                          y: startVertex.y,
+                          floor: widget.start.floor,
+                        );
+                  });
+                }
+              }
             }
 
             final result = _cachedPathResult;
@@ -290,13 +327,17 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
 
             // 사용자의 현재 건물과 층 정보 가져오기
             final navigationState = ref.watch(navigationViewModelProvider);
-            final buildingName = _getBuildingName(widget.start.buildingId);
-            final floorString = '${widget.start.floor}F';
 
-            // 지도 이미지 경로 (2x 해상도 사용)
+            // 관련된 건물 목록 추출 (건물 전환 버튼용)
+            final allPois = [widget.start, ...widget.waypoints, widget.end];
+            final involvedBuildings = allPois
+                .map((p) => getBuildingName(p.buildingId))
+                .toSet();
+
+            // 지도 이미지 경로 (2x 해상도 사용) - 현재 선택된 건물/층 기준
             final mapImagePath = MapUtilFunctions.getImagePath(
-              buildingName,
-              floorString,
+              _currentBuilding,
+              _currentFloor,
               '2x',
             );
 
@@ -322,8 +363,8 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                         // path_result_page에서는 '1x'를 기준으로 계산했음. 동일하게 맞춤
                         final calcOriginalSize =
                             MapUtilFunctions.getImageOriginalSize(
-                              buildingName,
-                              floorString,
+                              _currentBuilding,
+                              _currentFloor,
                               '1x',
                             );
 
@@ -344,7 +385,7 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                             (containerSize.height - displayedImageSize.height) /
                             2;
 
-                        // 초기 진입 시 애니메이션 실행
+                        // 초기 진입 시 애니메이션 실행 (지도 초기화 안 됐을 때만)
                         if (!_isMapInitialized) {
                           WidgetsBinding.instance.addPostFrameCallback((_) {
                             _animateToStart(
@@ -365,20 +406,15 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                             final v1 = pathFinder.vertices[fromId];
                             final v2 = pathFinder.vertices[toId];
 
-                            // 현재 층에 해당하는지 확인 (간단하게 ID 대역으로 체크하거나, vertex 정보에 층 정보가 있다면 활용)
-                            // 여기서는 path_result_page의 _isVertexOnCurrentMap 로직을 인라인으로 구현하거나 함수로 분리 필요
-                            // 일단 간단히 층 정보가 일치하는지만 체크 (v1, v2 좌표가 지도 범위 내인지 등)
-                            // 하지만 Vertex 자체에는 층 정보가 없으므로 ID 대역을 써야 함.
-                            // 이 페이지엔 _isVertexOnCurrentMap 함수가 없으므로 추가하거나, 간단히 구현
-
+                            // 현재 층에 해당하는지 확인
                             // 5호관 1층: 0~499, 2층: 500~999, 60주년 1층: 1000~
                             bool isVertexOnMap(int id) {
-                              if (buildingName == '5호관') {
-                                if (floorString == '1F') return id < 500;
-                                if (floorString == '2F') {
+                              if (_currentBuilding == '5호관') {
+                                if (_currentFloor == '1F') return id < 500;
+                                if (_currentFloor == '2F') {
                                   return id >= 500 && id < 1000;
                                 }
-                              } else if (buildingName.contains('60주년')) {
+                              } else if (_currentBuilding.contains('60주년')) {
                                 return id >= 1000;
                               }
                               return false;
@@ -454,6 +490,16 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                                   currentX = widget.start.xCoord;
                                   currentY = widget.start.yCoord;
                                   currentFloor = widget.start.floor;
+
+                                  // 경로 시작점(Vertex)이 있으면 해당 위치 사용
+                                  if (result.path.isNotEmpty) {
+                                    final startVertex =
+                                        pathFinder.vertices[result.path.first];
+                                    if (startVertex != null) {
+                                      currentX = startVertex.x;
+                                      currentY = startVertex.y;
+                                    }
+                                  }
                                 }
 
                                 // 1. 층 확인
@@ -509,7 +555,7 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
                                           ],
                                         ),
                                         child: Icon(
-                                          Icons.person_pin_circle,
+                                          Icons.person,
                                           color: AppColors.primary,
                                           size: 24,
                                         ),
@@ -572,6 +618,107 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
 
                             // 상단 상태 정보 (CountSteps)
                             CountSteps(navigationState: navigationState),
+
+                            // 건물 전환 버튼 (경로에 포함된 건물이 2개 이상일 때)
+                            if (involvedBuildings.length > 1)
+                              Positioned(
+                                bottom: 16,
+                                left: 16,
+                                child: GestureDetector(
+                                  onTap: () =>
+                                      _cycleBuildings(involvedBuildings),
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 16,
+                                      vertical: 12,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: Colors.white,
+                                      borderRadius: BorderRadius.circular(12),
+                                      boxShadow: [
+                                        BoxShadow(
+                                          color: Colors.black.withAlpha(10),
+                                          blurRadius: 4,
+                                          offset: const Offset(0, 2),
+                                        ),
+                                      ],
+                                    ),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Text(
+                                          _currentBuilding,
+                                          style: const TextStyle(
+                                            fontWeight: FontWeight.w600,
+                                            fontSize: 14,
+                                            color: AppColors.text,
+                                          ),
+                                        ),
+                                        const SizedBox(width: 4),
+                                        const Icon(
+                                          Icons.swap_horiz_rounded,
+                                          size: 16,
+                                          color: AppColors.text,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+
+                            // 층 이동 버튼
+                            Positioned(
+                              bottom: 16,
+                              right: 16,
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children:
+                                    MapUtilFunctions.getAvailableFloors(
+                                      _currentBuilding,
+                                    ).map((floor) {
+                                      // 해당 층에 마커가 있는지 확인 (빨간 뱃지용)
+                                      final bool hasPointOnThisFloor = allPois
+                                          .any((poi) {
+                                            // 현재 건물의 층에 해당하는 POI가 있는지 확인
+                                            // 건물 이름 비교가 필요함
+                                            final poiBuildingName =
+                                                getBuildingName(poi.buildingId);
+                                            return poiBuildingName ==
+                                                    _currentBuilding &&
+                                                '${poi.floor}F' == floor;
+                                          });
+
+                                      return Padding(
+                                        padding: const EdgeInsets.only(top: 8),
+                                        child: Stack(
+                                          clipBehavior: Clip.none,
+                                          alignment: Alignment.topRight,
+                                          children: [
+                                            FloorButton(
+                                              floor: floor,
+                                              isSelected:
+                                                  _currentFloor == floor,
+                                              onTap: () => _changeFloor(floor),
+                                            ),
+                                            if (hasPointOnThisFloor)
+                                              Positioned(
+                                                top: 6,
+                                                right: 6,
+                                                child: Container(
+                                                  width: 12,
+                                                  height: 12,
+                                                  decoration: BoxDecoration(
+                                                    color: AppColors.warning,
+                                                    shape: BoxShape.circle,
+                                                  ),
+                                                ),
+                                              ),
+                                          ],
+                                        ),
+                                      );
+                                    }).toList(),
+                              ),
+                            ),
                           ],
                         );
                       }, // LayoutBuilder builder

--- a/lib/presentation/ui/path/path_navi_page.dart
+++ b/lib/presentation/ui/path/path_navi_page.dart
@@ -21,11 +21,17 @@ class PathNaviPage extends ConsumerStatefulWidget {
   final Poi end;
   final List<Poi> waypoints;
 
+  // 계산된 경로를 받는 파라미터
+  final List<int>? preCalculatedPath;
+  final double? preCalculatedCost;
+
   const PathNaviPage({
     super.key,
     required this.start,
     required this.end,
     this.waypoints = const [],
+    this.preCalculatedPath,
+    this.preCalculatedCost,
   });
 
   @override
@@ -250,21 +256,32 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage>
             ),
           ),
           data: (pathFinder) {
+            // 캐싱된 경로가 없을 때
             if (_cachedPathResult == null) {
-              final List<int> visitOrder = [
-                widget.start.vertexId ?? -1,
-                ...widget.waypoints.map((e) => e.vertexId ?? -1),
-                widget.end.vertexId ?? -1,
-              ];
+              // 1. 만약 이전 페이지에서 넘겨준 계산된 경로가 있다면 그걸 사용
+              if (widget.preCalculatedPath != null &&
+                  widget.preCalculatedCost != null) {
+                _cachedPathResult = PathResult(
+                  path: widget.preCalculatedPath!,
+                  totalCost: widget.preCalculatedCost!,
+                );
+              }
+              // 2. 없다면 직접 계산
+              else {
+                final List<int> visitOrder = [
+                  widget.start.vertexId ?? -1,
+                  ...widget.waypoints.map((e) => e.vertexId ?? -1),
+                  widget.end.vertexId ?? -1,
+                ];
 
-              if (visitOrder.contains(-1)) {
-                return const Center(child: Text("유효하지 않은 위치 정보가 있습니다."));
+                if (!visitOrder.contains(-1)) {
+                  _cachedPathResult = pathFinder.findPathWithWaypoints(
+                    visitOrder,
+                  );
+                }
               }
 
-              // 경유지 포함하여 경로 탐색
-              _cachedPathResult = pathFinder.findPathWithWaypoints(visitOrder);
-
-              // 경로 시작 지점(Vertex)으로 초기 사용자 위치 설정
+              // 경로 시작 지점으로 초기 위치 설정 (한번만 실행)
               final calculatedPath = _cachedPathResult;
               if (calculatedPath != null && calculatedPath.path.isNotEmpty) {
                 final startVertexId = calculatedPath.path.first;

--- a/lib/presentation/ui/path/path_navi_page.dart
+++ b/lib/presentation/ui/path/path_navi_page.dart
@@ -1,5 +1,6 @@
 //import 'dart:convert';
 import 'dart:math' as math;
+import 'package:annyong/domain/usecases/path_finder.dart';
 import 'package:annyong/presentation/widgets/path_page/cost_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +10,8 @@ import 'package:annyong/domain/usecases/path_description_builder.dart';
 import 'package:annyong/presentation/viewmodels/navigation_view_model.dart';
 import 'package:annyong/presentation/util/map_util_funtions.dart';
 import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:annyong/presentation/ui/path/path_result_page.dart';
+import 'package:vector_math/vector_math_64.dart' as math64;
 
 class PathNaviPage extends ConsumerStatefulWidget {
   final Poi start;
@@ -26,7 +29,67 @@ class PathNaviPage extends ConsumerStatefulWidget {
   ConsumerState<PathNaviPage> createState() => _PathNaviPageState();
 }
 
-class _PathNaviPageState extends ConsumerState<PathNaviPage> {
+class RippleMarker extends StatefulWidget {
+  const RippleMarker({super.key});
+
+  @override
+  State<RippleMarker> createState() => _RippleMarkerState();
+}
+
+class _RippleMarkerState extends State<RippleMarker>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return SizedBox(
+          width: 60,
+          height: 60,
+          child: Center(
+            child: Container(
+              width: 60 * _controller.value, // 최대 크기 60
+              height: 60 * _controller.value,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.primary.withOpacity((1 - _controller.value)),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PathNaviPageState extends ConsumerState<PathNaviPage>
+    with SingleTickerProviderStateMixin {
+  final TransformationController _transformationController =
+      TransformationController();
+  late AnimationController _mapAnimationController;
+  Animation<Matrix4>? _mapAnimation;
+  //Size? _mapContainerSize;
+  bool _isMapInitialized = false;
+  // 경로 탐색 결과 캐싱
+  PathResult? _cachedPathResult;
+
   @override
   void initState() {
     super.initState();
@@ -36,10 +99,27 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage> {
       // 출발 POI로 초기 위치 설정
       navigationNotifier.setInitialPositionFromPoi(widget.start);
     });
+
+    _mapAnimationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+
+    _mapAnimationController.addListener(() {
+      if (_mapAnimation != null) {
+        _transformationController.value = _mapAnimation!.value;
+      }
+    });
+
+    _transformationController.addListener(() {
+      setState(() {});
+    });
   }
 
   @override
   void dispose() {
+    _transformationController.dispose();
+    _mapAnimationController.dispose();
     // 페이지 종료 시 길 안내 종료 및 초기화
     // 위젯 빌드 중 상태 변경을 방지하기 위해 다음 프레임에 실행
     Future.microtask(() {
@@ -53,6 +133,56 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage> {
       }
     });
     super.dispose();
+  }
+
+  // 초기 위치로 지도 이동 애니메이션
+  void _animateToStart(
+    Size containerSize,
+    Size displayedImageSize,
+    Size originalSize,
+  ) {
+    if (_isMapInitialized) return;
+
+    // 1. 스케일 계산
+    final scaleX = displayedImageSize.width / originalSize.width;
+    final scaleY = displayedImageSize.height / originalSize.height;
+
+    // 2. 이미지 오프셋 (중앙 정렬 보정)
+    final imageOffsetX = (containerSize.width - displayedImageSize.width) / 2;
+    final imageOffsetY = (containerSize.height - displayedImageSize.height) / 2;
+
+    // 3. 목표 줌 레벨 설정
+    const double targetZoom = 3.0;
+
+    // 4. 목표 중심점 계산 (출발지 좌표 기준)
+    // 이미지 내에서의 절대 좌표
+    final targetX = widget.start.xCoord * scaleX + imageOffsetX;
+    final targetY = widget.start.yCoord * scaleY + imageOffsetY;
+
+    // 5. 화면 중앙에 위치시키기 위한 Translation 계산
+    // 화면 중앙 - (타겟 좌표 * 줌)
+    final translateX = (containerSize.width / 2) - (targetX * targetZoom);
+    final translateY = (containerSize.height / 2) - (targetY * targetZoom);
+
+    // 6. 목표 매트릭스 생성
+    final targetMatrix = Matrix4.identity()
+      ..translateByVector3(math64.Vector3(translateX, translateY, 0))
+      ..scale(targetZoom);
+
+    // 7. 애니메이션 실행
+    _mapAnimation =
+        Matrix4Tween(
+          begin: _transformationController.value,
+          end: targetMatrix,
+        ).animate(
+          CurvedAnimation(
+            parent: _mapAnimationController,
+            curve: Curves.easeInOutCubic,
+          ),
+        );
+
+    _mapAnimationController.forward(from: 0);
+    _isMapInitialized = true;
   }
 
   /// buildingId를 건물 이름으로 변환
@@ -97,21 +227,26 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage> {
             ),
           ),
           data: (pathFinder) {
-            // 방문해야 할 모든 지점의 Vertex ID를 순서대로 리스트화
-            // 유효하지 않은 것은 -1로 대체
-            final List<int> visitOrder = [
-              widget.start.vertexId ?? -1,
-              ...widget.waypoints.map((e) => e.vertexId ?? -1),
-              widget.end.vertexId ?? -1,
-            ];
+            // 캐싱된 결과가 있으면 재사용, 없으면 새로 계산
+            if (_cachedPathResult == null) {
+              // 방문해야 할 모든 지점의 Vertex ID를 순서대로 리스트화
+              // 유효하지 않은 것은 -1로 대체
+              final List<int> visitOrder = [
+                widget.start.vertexId ?? -1,
+                ...widget.waypoints.map((e) => e.vertexId ?? -1),
+                widget.end.vertexId ?? -1,
+              ];
 
-            // 유효하지 않은 정점이 있을 때 예외 처리
-            if (visitOrder.contains(-1)) {
-              return const Center(child: Text("유효하지 않은 위치 정보가 있습니다."));
+              // 유효하지 않은 정점이 있을 때 예외 처리
+              if (visitOrder.contains(-1)) {
+                return const Center(child: Text("유효하지 않은 위치 정보가 있습니다."));
+              }
+
+              // 경유지 포함하여 경로 탐색
+              _cachedPathResult = pathFinder.findPathWithWaypoints(visitOrder);
             }
 
-            // 경유지 포함하여 경로 탐색
-            final result = pathFinder.findPathWithWaypoints(visitOrder);
+            final result = _cachedPathResult;
 
             // 경로 못 찾았을 때 UI 처리
             if (result == null || result.path.isEmpty) {
@@ -150,12 +285,6 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage> {
               result.totalCost,
             );
 
-            //const JsonEncoder encoder = JsonEncoder.withIndent('  ');
-            //final String prettyJson = encoder.convert(jsonResult);
-            //debugPrint('----------- [Path Result JSON Start] -----------');
-            //debugPrint(prettyJson);
-            //debugPrint('----------- [Path Result JSON End] -----------');
-
             // 유효한 경로 찾았을 때 UI 렌더링
             final double totalCost = jsonResult['total_cost'] ?? 0.0;
 
@@ -171,126 +300,286 @@ class _PathNaviPageState extends ConsumerState<PathNaviPage> {
               '2x',
             );
 
-            return SingleChildScrollView(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // ------------------출발, 경유, 도착, 총 비용------------------
-                  CostCard(
+            return Column(
+              children: [
+                // ------------------출발, 경유, 도착, 총 비용------------------
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: CostCard(
                     departure: widget.start.name,
                     destination: widget.end.name,
                     totalCost: totalCost,
                     waypoints: widget.waypoints,
                   ),
-                  const SizedBox(height: 20),
-                  // ------------------지도 및 사용자 위치------------------
-                  Container(
-                    height: 300,
-                    margin: const EdgeInsets.only(bottom: 16),
-                    decoration: BoxDecoration(
-                      color: AppColors.grey200,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(20),
-                      child: Stack(
-                        children: [
-                          // 지도 이미지
-                          Positioned.fill(
-                            child: Image.asset(
-                              mapImagePath,
-                              fit: BoxFit.contain,
-                            ),
-                          ),
-                          // 사용자 위치 마커 (현재 층일 때만 표시)
-                          navigationState.when(
-                            data: (state) {
-                              // 현재 지도 층과 사용자 층이 일치할 때만 마커 표시
-                              if (state.floor != widget.start.floor) {
-                                return const SizedBox.shrink();
+                ),
+                // ------------------지도 및 사용자 위치------------------
+                Expanded(
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        final containerSize = constraints.biggest;
+                        // path_result_page에서는 '1x'를 기준으로 계산했음. 동일하게 맞춤
+                        final calcOriginalSize =
+                            MapUtilFunctions.getImageOriginalSize(
+                              buildingName,
+                              floorString,
+                              '1x',
+                            );
+
+                        final displayedImageSize =
+                            MapUtilFunctions.getDisplayedImageSize(
+                              containerSize,
+                              calcOriginalSize,
+                            );
+
+                        final scaleX =
+                            displayedImageSize.width / calcOriginalSize.width;
+                        final scaleY =
+                            displayedImageSize.height / calcOriginalSize.height;
+                        final imageOffsetX =
+                            (containerSize.width - displayedImageSize.width) /
+                            2;
+                        final imageOffsetY =
+                            (containerSize.height - displayedImageSize.height) /
+                            2;
+
+                        // 초기 진입 시 애니메이션 실행
+                        if (!_isMapInitialized) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            _animateToStart(
+                              containerSize,
+                              displayedImageSize,
+                              calcOriginalSize,
+                            );
+                          });
+                        }
+
+                        // 경로 좌표 계산 로직 (path_result_page 복사)
+                        final List<Offset> pathPoints = [];
+
+                        if (result.path.length > 1) {
+                          for (int i = 0; i < result.path.length - 1; i++) {
+                            final int fromId = result.path[i];
+                            final int toId = result.path[i + 1];
+                            final v1 = pathFinder.vertices[fromId];
+                            final v2 = pathFinder.vertices[toId];
+
+                            // 현재 층에 해당하는지 확인 (간단하게 ID 대역으로 체크하거나, vertex 정보에 층 정보가 있다면 활용)
+                            // 여기서는 path_result_page의 _isVertexOnCurrentMap 로직을 인라인으로 구현하거나 함수로 분리 필요
+                            // 일단 간단히 층 정보가 일치하는지만 체크 (v1, v2 좌표가 지도 범위 내인지 등)
+                            // 하지만 Vertex 자체에는 층 정보가 없으므로 ID 대역을 써야 함.
+                            // 이 페이지엔 _isVertexOnCurrentMap 함수가 없으므로 추가하거나, 간단히 구현
+
+                            // 5호관 1층: 0~499, 2층: 500~999, 60주년 1층: 1000~
+                            bool isVertexOnMap(int id) {
+                              if (buildingName == '5호관') {
+                                if (floorString == '1F') return id < 500;
+                                if (floorString == '2F') {
+                                  return id >= 500 && id < 1000;
+                                }
+                              } else if (buildingName.contains('60주년')) {
+                                return id >= 1000;
                               }
+                              return false;
+                            }
 
-                              // 사용자 좌표를 화면 좌표로 변환
-                              // (search_result_page와 동일한 변환 로직 사용)
-                              final scaledX = state.x * 0.19;
-                              final scaledY = state.y * 0.19;
-                              final adjustedX = scaledX - 10;
-                              final adjustedY = scaledY + 50;
+                            if (v1 != null &&
+                                v2 != null &&
+                                isVertexOnMap(fromId) &&
+                                isVertexOnMap(toId)) {
+                              final p1x = v1.x * scaleX;
+                              final p1y = v1.y * scaleY;
+                              final p2x = v2.x * scaleX;
+                              final p2y = v2.y * scaleY;
 
-                              return Positioned(
-                                left: adjustedX - 12,
-                                top: adjustedY - 24,
-                                child: Container(
-                                  padding: const EdgeInsets.all(4),
-                                  decoration: BoxDecoration(
-                                    color: Colors.white,
-                                    shape: BoxShape.circle,
-                                    boxShadow: [
-                                      BoxShadow(
-                                        color: Colors.black.withValues(
-                                          alpha: 0.3,
+                              pathPoints.add(Offset(p1x, p1y));
+                              pathPoints.add(Offset(p2x, p2y));
+                            }
+                          }
+                        }
+
+                        return Stack(
+                          children: [
+                            // InteractiveViewer로 감싼 지도 및 경로
+                            Positioned.fill(
+                              child: InteractiveViewer(
+                                transformationController:
+                                    _transformationController,
+                                minScale: 1.0,
+                                maxScale: 4.0,
+                                child: Center(
+                                  child: SizedBox(
+                                    width: displayedImageSize.width,
+                                    height: displayedImageSize.height,
+                                    child: Stack(
+                                      children: [
+                                        // 지도 이미지
+                                        Image.asset(
+                                          mapImagePath,
+                                          fit: BoxFit.contain,
+                                          width: displayedImageSize.width,
+                                          height: displayedImageSize.height,
                                         ),
-                                        blurRadius: 8,
-                                        offset: const Offset(0, 2),
-                                      ),
-                                    ],
-                                  ),
-                                  child: Icon(
-                                    Icons.person_pin_circle,
-                                    color: AppColors.primary,
-                                    size: 24,
-                                  ),
-                                ),
-                              );
-                            },
-                            loading: () => const SizedBox.shrink(),
-                            error: (_, __) => const SizedBox.shrink(),
-                          ),
-                          // 도착지 마커 (현재 층일 때만 표시)
-                          if (widget.end.floor == widget.start.floor)
-                            Builder(
-                              builder: (context) {
-                                // 도착지 POI 좌표를 화면 좌표로 변환
-                                final scaledX = widget.end.xCoord * 0.19;
-                                final scaledY = widget.end.yCoord * 0.19;
-                                final adjustedX = scaledX - 10;
-                                final adjustedY = scaledY + 50;
-
-                                return Positioned(
-                                  left: adjustedX - 12,
-                                  top: adjustedY - 24,
-                                  child: Container(
-                                    padding: const EdgeInsets.all(4),
-                                    decoration: BoxDecoration(
-                                      color: Colors.white,
-                                      shape: BoxShape.circle,
-                                      boxShadow: [
-                                        BoxShadow(
-                                          color: Colors.black.withValues(
-                                            alpha: 0.3,
+                                        // 경로 그리기
+                                        IgnorePointer(
+                                          child: CustomPaint(
+                                            size: Size(
+                                              displayedImageSize.width,
+                                              displayedImageSize.height,
+                                            ),
+                                            painter: PathPainter(
+                                              // path_result_page.dart에서 import됨
+                                              points: pathPoints,
+                                              color: AppColors.primary,
+                                            ),
                                           ),
-                                          blurRadius: 8,
-                                          offset: const Offset(0, 2),
                                         ),
                                       ],
                                     ),
-                                    child: Icon(
-                                      Icons.location_on,
-                                      color: Colors.red,
-                                      size: 24,
-                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+
+                            // 사용자 위치 마커 (InteractiveViewer 좌표 변환 적용)
+                            navigationState.when(
+                              data: (state) {
+                                double currentX = state.x;
+                                double currentY = state.y;
+                                int currentFloor = state.floor;
+
+                                // 초기화되지 않은 좌표(0,0)인 경우 출발지 정보 사용
+                                if (state.x == 0 && state.y == 0) {
+                                  currentX = widget.start.xCoord;
+                                  currentY = widget.start.yCoord;
+                                  currentFloor = widget.start.floor;
+                                }
+
+                                // 1. 층 확인
+                                if (currentFloor != widget.start.floor) {
+                                  return const SizedBox.shrink();
+                                }
+
+                                // 사용자 좌표 -> 화면 좌표 변환
+                                // state.x, state.y는 원본 좌표계 기준이라 가정
+                                // path_result_page와 동일하게 스케일 적용
+                                // 단, 기존 코드에서 0.19를 곱하던 것은 하드코딩된 값이므로,
+                                // 여기서는 계산된 scaleX, scaleY를 사용하는 것이 정확함.
+                                // 하지만 기존 코드가 0.19를 쓴 이유(지도 원본 해상도 차이 등)를 고려해야 함.
+                                // 일단 위에서 계산한 scaleX, scaleY를 사용하여 동적으로 맞춤.
+
+                                final localX = currentX * scaleX + imageOffsetX;
+                                final localY = currentY * scaleY + imageOffsetY;
+
+                                // Matrix 적용하여 현재 화면상 좌표 계산
+                                final currentMatrix =
+                                    _transformationController.value;
+                                final screenX =
+                                    currentMatrix.storage[0] * localX +
+                                    currentMatrix.storage[4] * localY +
+                                    currentMatrix.storage[12];
+                                final screenY =
+                                    currentMatrix.storage[1] * localX +
+                                    currentMatrix.storage[5] * localY +
+                                    currentMatrix.storage[13];
+
+                                return Positioned(
+                                  left: screenX - 30, // Ripple 최대 크기(60)의 절반
+                                  top:
+                                      screenY -
+                                      42, // 아이콘 위치 보정 (24 + 36의 중간점 고려)
+                                  child: Stack(
+                                    alignment: Alignment.center,
+                                    children: [
+                                      const RippleMarker(),
+                                      Container(
+                                        padding: const EdgeInsets.all(4),
+                                        decoration: BoxDecoration(
+                                          color: Colors.white,
+                                          shape: BoxShape.circle,
+                                          boxShadow: [
+                                            BoxShadow(
+                                              color: Colors.black.withValues(
+                                                alpha: 0.3,
+                                              ),
+                                              blurRadius: 8,
+                                              offset: const Offset(0, 2),
+                                            ),
+                                          ],
+                                        ),
+                                        child: Icon(
+                                          Icons.person_pin_circle,
+                                          color: AppColors.primary,
+                                          size: 24,
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 );
                               },
+                              loading: () => const SizedBox.shrink(),
+                              error: (_, __) => const SizedBox.shrink(),
                             ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            );
+
+                            // 도착지 마커
+                            if (widget.end.floor == widget.start.floor)
+                              Builder(
+                                builder: (context) {
+                                  final localX =
+                                      widget.end.xCoord * scaleX + imageOffsetX;
+                                  final localY =
+                                      widget.end.yCoord * scaleY + imageOffsetY;
+
+                                  final currentMatrix =
+                                      _transformationController.value;
+                                  final screenX =
+                                      currentMatrix.storage[0] * localX +
+                                      currentMatrix.storage[4] * localY +
+                                      currentMatrix.storage[12];
+                                  final screenY =
+                                      currentMatrix.storage[1] * localX +
+                                      currentMatrix.storage[5] * localY +
+                                      currentMatrix.storage[13];
+
+                                  return Positioned(
+                                    left: screenX - 12,
+                                    top: screenY - 24,
+                                    child: Container(
+                                      padding: const EdgeInsets.all(4),
+                                      decoration: BoxDecoration(
+                                        color: Colors.white,
+                                        shape: BoxShape.circle,
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: Colors.black.withValues(
+                                              alpha: 0.3,
+                                            ),
+                                            blurRadius: 8,
+                                            offset: const Offset(0, 2),
+                                          ),
+                                        ],
+                                      ),
+                                      child: Icon(
+                                        Icons.location_on,
+                                        color: Colors.red,
+                                        size: 24,
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+
+                            // 상단 상태 정보 (CountSteps)
+                            CountSteps(navigationState: navigationState),
+                          ],
+                        );
+                      }, // LayoutBuilder builder
+                    ), // LayoutBuilder
+                  ), // Container
+                ), // Expanded
+              ],
+            ); // Column
           },
         ),
       ),

--- a/lib/presentation/ui/path/path_result_page.dart
+++ b/lib/presentation/ui/path/path_result_page.dart
@@ -21,19 +21,86 @@ class PathPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     if (points.isEmpty) return;
 
-    final paint = Paint()
-      ..color = color
-      ..strokeWidth = 2
+    // 1. 경로 생성 (하나의 Path로 연결)
+    final path = Path();
+    if (points.isNotEmpty) {
+      path.moveTo(points[0].dx, points[0].dy);
+      for (int i = 1; i < points.length; i++) {
+        // 불연속적인 점(선분의 시작점이 이전 선분의 끝점과 다를 경우) 처리
+        // points 구조: [p1, p2, p3, p4, ...] (이미 연결된 순서로 온다고 가정해야 함)
+        // 하지만 호출부 로직을 보면 [시작1, 끝1, 시작2, 끝2] 형태로 들어옴
+        // 따라서 i가 홀수일 때(끝점)는 lineTo, 짝수일 때(시작점)는 체크 필요
+
+        // 호출부 로직: pathPoints.add(Offset(p1x, p1y)); pathPoints.add(Offset(p2x, p2y));
+        // 즉, i=0(시작), i=1(끝), i=2(시작), i=3(끝) ...
+
+        if (i % 2 == 0) {
+          // 새로운 선분의 시작점
+          // 이전 선분의 끝점(points[i-1])과 현재 시작점(points[i])이 같으면 이어그리기(아무것도 안 함, 다음 루프에서 lineTo로 이어짐)
+          // 다르면 끊어서 이동
+          if (points[i] != points[i - 1]) {
+            path.moveTo(points[i].dx, points[i].dy);
+          }
+        } else {
+          // 선분의 끝점
+          path.lineTo(points[i].dx, points[i].dy);
+        }
+      }
+    }
+
+    // 2. 테두리 그리기 (흰색, 더 두껍게)
+    final borderPaint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 6
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round
       ..strokeJoin = StrokeJoin.round;
 
-    //final path = Path();
-    // 선이 끊기지 않고 이어지도록 하기 위해 path.lineTo 사용
-    // points 구조: [시작점1, 끝점1, 시작점2, 끝점2, ...]
-    // TODO: 층이 바뀌는 등 불연속적인 구간은 points 리스트 구성 시 처리 필요
-    for (int i = 0; i < points.length - 1; i += 2) {
-      canvas.drawLine(points[i], points[i + 1], paint);
+    canvas.drawPath(path, borderPaint);
+
+    // 3. 경로 그리기 (기존 색상, 기존 두께)
+    final pathPaint = Paint()
+      ..color = color
+      ..strokeWidth = 4
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    canvas.drawPath(path, pathPaint);
+
+    // 화살표
+    final arrowPaint = Paint()
+      ..color = AppColors.secondary
+      ..style = PaintingStyle.fill;
+
+    // 경로를 따라가며 일정 간격마다 화살표 배치
+    for (final metric in path.computeMetrics()) {
+      const double dashWidth = 20.0; // 화살표 간격
+      const double arrowSize = 1.5; // 화살표 크기
+
+      double distance = dashWidth;
+      while (distance < metric.length) {
+        final tangent = metric.getTangentForOffset(distance);
+        if (tangent != null) {
+          final position = tangent.position;
+          final angle = -tangent.angle; // Canvas 좌표계와 atan2 방향 고려
+
+          canvas.save();
+          canvas.translate(position.dx, position.dy);
+          canvas.rotate(angle); // 진행 방향으로 회전
+
+          // 화살표 모양 그리기 (삼각형)
+          final arrowPath = Path()
+            ..moveTo(-arrowSize, -arrowSize) // 왼쪽 위
+            ..lineTo(arrowSize, 0) // 오른쪽 중앙 (화살표 끝)
+            ..lineTo(-arrowSize, arrowSize) // 왼쪽 아래
+            ..close();
+
+          canvas.drawPath(arrowPath, arrowPaint);
+          canvas.restore();
+        }
+        distance += 40.0; // 다음 화살표까지 거리
+      }
     }
   }
 

--- a/lib/presentation/ui/path/path_result_page.dart
+++ b/lib/presentation/ui/path/path_result_page.dart
@@ -28,7 +28,7 @@ class PathPainter extends CustomPainter {
       ..strokeCap = StrokeCap.round
       ..strokeJoin = StrokeJoin.round;
 
-    final path = Path();
+    //final path = Path();
     // 선이 끊기지 않고 이어지도록 하기 위해 path.lineTo 사용
     // points 구조: [시작점1, 끝점1, 시작점2, 끝점2, ...]
     // TODO: 층이 바뀌는 등 불연속적인 구간은 points 리스트 구성 시 처리 필요
@@ -364,8 +364,8 @@ class _PathResultPageState extends ConsumerState<PathResultPage> {
                                             shape: BoxShape.circle,
                                             boxShadow: [
                                               BoxShadow(
-                                                color: Colors.black.withOpacity(
-                                                  0.2,
+                                                color: Colors.black.withAlpha(
+                                                  20,
                                                 ),
                                                 blurRadius: 6,
                                                 offset: const Offset(0, 4),
@@ -429,9 +429,7 @@ class _PathResultPageState extends ConsumerState<PathResultPage> {
                                           ),
                                           boxShadow: [
                                             BoxShadow(
-                                              color: Colors.black.withOpacity(
-                                                0.1,
-                                              ),
+                                              color: Colors.black.withAlpha(10),
                                               blurRadius: 4,
                                               offset: const Offset(0, 2),
                                             ),
@@ -542,7 +540,7 @@ class _PathResultPageState extends ConsumerState<PathResultPage> {
                     color: Colors.white,
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.05),
+                        color: Colors.black.withAlpha(5),
                         blurRadius: 10,
                         offset: const Offset(0, -4),
                       ),

--- a/lib/presentation/ui/path/path_result_page.dart
+++ b/lib/presentation/ui/path/path_result_page.dart
@@ -1,3 +1,4 @@
+import 'package:annyong/domain/usecases/path_finder.dart';
 import 'package:annyong/presentation/widgets/home_page/floor_button.dart';
 import 'package:annyong/presentation/widgets/path_page/cost_card.dart';
 import 'package:flutter/material.dart';
@@ -132,6 +133,7 @@ class _PathResultPageState extends ConsumerState<PathResultPage> {
 
   late String _currentBuilding;
   late String _currentFloor;
+  PathResult? _cachedPathResult; // 경로 탐색 결과 캐싱용
 
   @override
   void initState() {
@@ -159,6 +161,9 @@ class _PathResultPageState extends ConsumerState<PathResultPage> {
         'start': widget.start,
         'end': widget.end,
         'waypoints': widget.waypoints,
+        // 캐싱된 결과가 있다면 함께 전달
+        'preCalculatedPath': _cachedPathResult?.path,
+        'preCalculatedCost': _cachedPathResult?.totalCost,
       },
     );
   }
@@ -211,18 +216,23 @@ class _PathResultPageState extends ConsumerState<PathResultPage> {
           error: (err, stack) => Center(child: Text('오류 발생: $err')),
           data: (pathFinder) {
             // 경로 계산 로직
-            final List<int> visitOrder = [
-              widget.start.vertexId ?? -1,
-              ...widget.waypoints.map((e) => e.vertexId ?? -1),
-              widget.end.vertexId ?? -1,
-            ];
+            // 캐싱된 결과가 없을 때에만 경로 탐색 실행
+            if (_cachedPathResult == null) {
+              final List<int> visitOrder = [
+                widget.start.vertexId ?? -1,
+                ...widget.waypoints.map((e) => e.vertexId ?? -1),
+                widget.end.vertexId ?? -1,
+              ];
 
-            if (visitOrder.contains(-1)) {
-              return const Center(child: Text("유효하지 않은 위치 정보가 있습니다."));
+              if (visitOrder.contains(-1)) {
+                return const Center(child: Text("유효하지 않은 위치 정보가 있습니다."));
+              }
+
+              // 결과 저장
+              _cachedPathResult = pathFinder.findPathWithWaypoints(visitOrder);
             }
 
-            final result = pathFinder.findPathWithWaypoints(visitOrder);
-
+            final result = _cachedPathResult;
             if (result == null || result.path.isEmpty) {
               return const Center(child: Text('경로를 찾을 수 없습니다'));
             }

--- a/lib/presentation/ui/path/path_selection_page.dart
+++ b/lib/presentation/ui/path/path_selection_page.dart
@@ -11,6 +11,7 @@ import 'package:annyong/presentation/widgets/path_page/reset_button.dart';
 import 'package:annyong/presentation/util/map_util_funtions.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:annyong/presentation/widgets/home_page/floor_button.dart';
+import 'package:vector_math/vector_math_64.dart' as math64;
 
 class PathSelectionPage extends ConsumerStatefulWidget {
   const PathSelectionPage({super.key});
@@ -197,7 +198,7 @@ class _PathSelectionPageState extends ConsumerState<PathSelectionPage>
             _mapContainerSize!.height / 2);
 
     final targetMatrix = Matrix4.identity()
-      ..translate(targetX, targetY)
+      ..translateByVector3(math64.Vector3(targetX, targetY, 0))
       ..scale(targetZoom);
 
     _mapAnimation =

--- a/lib/presentation/ui/path/path_selection_page.dart
+++ b/lib/presentation/ui/path/path_selection_page.dart
@@ -371,7 +371,7 @@ class _PathSelectionPageState extends ConsumerState<PathSelectionPage>
                   border: Border.all(color: AppColors.grey200, width: 1),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.05),
+                      color: Colors.black.withAlpha(5),
                       blurRadius: 20,
                       offset: const Offset(2, 4),
                       spreadRadius: 0,
@@ -556,8 +556,9 @@ class _PathSelectionPageState extends ConsumerState<PathSelectionPage>
                                               shape: BoxShape.circle,
                                               boxShadow: [
                                                 BoxShadow(
-                                                  color: Colors.black
-                                                      .withOpacity(0.2),
+                                                  color: Colors.black.withAlpha(
+                                                    20,
+                                                  ),
                                                   blurRadius: 6,
                                                   offset: const Offset(0, 4),
                                                 ),
@@ -631,7 +632,7 @@ class _PathSelectionPageState extends ConsumerState<PathSelectionPage>
                                       borderRadius: BorderRadius.circular(12),
                                       boxShadow: [
                                         BoxShadow(
-                                          color: Colors.black.withOpacity(0.1),
+                                          color: Colors.black.withAlpha(10),
                                           blurRadius: 4,
                                           offset: const Offset(0, 2),
                                         ),

--- a/lib/presentation/ui/search/search_result_page.dart
+++ b/lib/presentation/ui/search/search_result_page.dart
@@ -12,6 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:annyong/presentation/util/search_result_page_util.dart';
 import 'package:annyong/presentation/widgets/search_page/map_marker_widget.dart';
+import 'package:vector_math/vector_math_64.dart' as math64;
 
 class SearchResultPage extends ConsumerStatefulWidget {
   final String? searchKeyword;
@@ -133,7 +134,7 @@ class _SearchResultPageState extends ConsumerState<SearchResultPage>
 
     // 5. 이동 행렬 생성
     final targetMatrix = Matrix4.identity()
-      ..translate(targetX, targetY)
+      ..translateByVector3(math64.Vector3(targetX, targetY, 0))
       ..scale(targetZoom);
 
     // 6. 애니메이션 실행

--- a/lib/presentation/ui/search/search_rooms_page.dart
+++ b/lib/presentation/ui/search/search_rooms_page.dart
@@ -262,8 +262,7 @@ class _SearchRoomsPageState extends ConsumerState<SearchRoomsPage> {
                   child: Stack(
                     children: [
                       CategoryBox(
-                        categoryName:
-                            "${widget.searchType.replaceAll('\n', '/')}",
+                        categoryName: widget.searchType.replaceAll('\n', '/'),
                       ),
                       if (selectedClassroom != null) SelectedCategoryFlag(),
                     ],

--- a/lib/presentation/util/get_building_name.dart
+++ b/lib/presentation/util/get_building_name.dart
@@ -1,0 +1,12 @@
+String getBuildingName(int buildingId) {
+  switch (buildingId) {
+    case 1:
+      return "5호관";
+    case 2:
+      return "60주년기념관";
+    case 3:
+      return "하이테크관";
+    default:
+      return "5호관";
+  }
+}

--- a/lib/presentation/viewmodels/Navigation_view_model.dart
+++ b/lib/presentation/viewmodels/Navigation_view_model.dart
@@ -8,27 +8,18 @@ import 'dart:math' as math;
 
 /// 사용자의 현재 위치 및 네비게이션 상태
 class NavigationState {
-  /// 현재 X 좌표 (미터 단위)
-  final double x;
-
-  /// 현재 Y 좌표 (미터 단위)
-  final double y;
-
-  /// 현재 층수
-  final int floor;
-
-  /// 사용자가 바라보는 방향 (라디안, 0 = 북쪽, 시계방향)
-  final double heading;
-
-  /// 현재까지의 총 걸음수
-  final int stepCount;
-
-  /// 초기 걸음수 (측정 시작 시점)
-  final int initialStepCount;
+  final double x; // 현재 X 좌표 (미터 단위)
+  final double y; // 현재 Y 좌표 (미터 단위)
+  final int floor; // 현재 층수
+  final int buildingId; // 현재 건물
+  final double heading; // 사용자가 바라보는 방향 (라디안, 0 = 북쪽, 시계방향)
+  final int stepCount; // 현재까지의 총 걸음수
+  final int initialStepCount; // 초기 걸음수 (측정 시작 시점)
 
   NavigationState({
     this.x = 0.0,
     this.y = 0.0,
+    this.buildingId = 1,
     this.floor = 1,
     this.heading = 0.0,
     this.stepCount = 0,
@@ -38,6 +29,7 @@ class NavigationState {
   NavigationState copyWith({
     double? x,
     double? y,
+    int? buildingId,
     int? floor,
     double? heading,
     int? stepCount,
@@ -46,6 +38,7 @@ class NavigationState {
     return NavigationState(
       x: x ?? this.x,
       y: y ?? this.y,
+      buildingId: buildingId ?? this.buildingId,
       floor: floor ?? this.floor,
       heading: heading ?? this.heading,
       stepCount: stepCount ?? this.stepCount,
@@ -199,6 +192,7 @@ class NavigationViewModel extends AsyncNotifier<NavigationState> {
     required double beaconX,
     required double beaconY,
     required int beaconFloor,
+    required int beaconBuildingId,
     required double signalStrength,
   }) {
     if (signalStrength >= -65) {
@@ -206,7 +200,12 @@ class NavigationViewModel extends AsyncNotifier<NavigationState> {
       // 길찾기 중일 때만
       if (currentState != null) {
         state = AsyncValue.data(
-          currentState.copyWith(x: beaconX, y: beaconY, floor: beaconFloor),
+          currentState.copyWith(
+            x: beaconX,
+            y: beaconY,
+            floor: beaconFloor,
+            buildingId: beaconBuildingId,
+          ),
         );
       }
     }
@@ -217,6 +216,7 @@ class NavigationViewModel extends AsyncNotifier<NavigationState> {
     required double x,
     required double y,
     required int floor,
+    int buildingId = 1,
     double? heading,
   }) {
     final currentState = state.value;
@@ -227,6 +227,7 @@ class NavigationViewModel extends AsyncNotifier<NavigationState> {
           y: y,
           floor: floor,
           heading: heading ?? currentState.heading,
+          buildingId: buildingId,
         ),
       );
     }
@@ -244,6 +245,7 @@ class NavigationViewModel extends AsyncNotifier<NavigationState> {
           heading: heading ?? currentState.heading,
           stepCount: 0,
           initialStepCount: 0,
+          buildingId: departurePoi.buildingId,
         ),
       );
     }

--- a/lib/presentation/widgets/path_page/cost_card.dart
+++ b/lib/presentation/widgets/path_page/cost_card.dart
@@ -43,7 +43,7 @@ class _CostCardState extends State<CostCard> {
           border: Border.all(color: AppColors.grey200, width: 1),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.05),
+              color: Colors.black.withAlpha(5),
               blurRadius: 10,
               offset: const Offset(2, 4),
             ),
@@ -104,7 +104,7 @@ class _CostCardState extends State<CostCard> {
           margin: const EdgeInsets.only(left: 12),
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
           decoration: BoxDecoration(
-            color: AppColors.primary.withOpacity(0.1),
+            color: AppColors.primary.withAlpha(10),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Text(
@@ -191,7 +191,7 @@ class _CostCardState extends State<CostCard> {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: AppColors.primary.withOpacity(0.1),
+                color: AppColors.primary.withAlpha(10),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Text(

--- a/lib/presentation/widgets/path_page/location_input_tile.dart
+++ b/lib/presentation/widgets/path_page/location_input_tile.dart
@@ -45,8 +45,8 @@ class _LocationInputTileState extends State<LocationInputTile> {
           boxShadow: [
             BoxShadow(
               color: _isPressed
-                  ? AppColors.primary.withOpacity(0.25)
-                  : Colors.black.withOpacity(0.05),
+                  ? AppColors.primary.withAlpha(25)
+                  : Colors.black.withAlpha(5),
               blurRadius: 10,
               offset: const Offset(2, 4),
               spreadRadius: 0,

--- a/lib/presentation/widgets/path_page/outdoor_page.dart
+++ b/lib/presentation/widgets/path_page/outdoor_page.dart
@@ -1,0 +1,111 @@
+import 'package:annyong/presentation/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class OutdoorPage extends StatelessWidget {
+  final String destinationBuildingName;
+  final VoidCallback onForceIndoor; // [추가] 강제 실내 전환 콜백
+
+  const OutdoorPage({
+    super.key,
+    required this.destinationBuildingName,
+    required this.onForceIndoor, // [추가]
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      width: double.infinity,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(30),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withOpacity(0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              Icons.directions_walk_rounded,
+              size: 80,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(height: 30),
+          const Text(
+            "현재 실외 이동 중입니다",
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w700,
+              color: AppColors.text,
+              fontFamily: 'Pretendard',
+            ),
+          ),
+          const SizedBox(height: 16),
+          RichText(
+            textAlign: TextAlign.center,
+            text: TextSpan(
+              style: const TextStyle(
+                fontSize: 18,
+                color: Color(0xFF555555),
+                height: 1.5,
+                fontFamily: 'Pretendard',
+              ),
+              children: [
+                TextSpan(
+                  text: destinationBuildingName,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primary,
+                  ),
+                ),
+                const TextSpan(text: " 입구에 도착하면\n자동으로 실내 지도로 전환됩니다."),
+              ],
+            ),
+          ),
+          const SizedBox(height: 40),
+
+          // [추가] GPS 상태 표시
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            margin: const EdgeInsets.only(bottom: 20),
+            decoration: BoxDecoration(
+              color: Colors.grey[100],
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.gps_fixed, size: 16, color: Colors.green),
+                SizedBox(width: 8),
+                Text(
+                  "GPS 신호 수신 중",
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ],
+            ),
+          ),
+
+          // [핵심 추가] 강제 실내 전환 버튼
+          // 인식 오류 시 사용자가 직접 탈출할 수 있는 수단 제공
+          TextButton.icon(
+            onPressed: onForceIndoor,
+            icon: const Icon(
+              Icons.map_outlined,
+              size: 18,
+              color: AppColors.grey400,
+            ),
+            label: const Text(
+              "실내 지도로 보기",
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColors.grey400,
+                decoration: TextDecoration.underline,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/search_page/map_marker_widget.dart
+++ b/lib/presentation/widgets/search_page/map_marker_widget.dart
@@ -34,8 +34,8 @@ class MapMarkerWidget extends StatelessWidget {
               boxShadow: [
                 BoxShadow(
                   color: isSelected
-                      ? AppColors.primary.withOpacity(0.5) // 선택: 파란색 그림자
-                      : Colors.black.withOpacity(0.2), // 미선택: 연회색 그림자
+                      ? AppColors.primary.withAlpha(5) // 선택: 파란색 그림자
+                      : Colors.black.withAlpha(20), // 미선택: 연회색 그림자
                   blurRadius: isSelected ? 12 : 6,
                   offset: const Offset(0, 4),
                   spreadRadius: isSelected ? 2 : 0,

--- a/lib/presentation/widgets/search_page/search_facilities_tile.dart
+++ b/lib/presentation/widgets/search_page/search_facilities_tile.dart
@@ -72,8 +72,8 @@ class _SearchFacilitiesTileState extends State<SearchFacilitiesTile> {
           boxShadow: [
             BoxShadow(
               color: _isPressed
-                  ? AppColors.primary.withOpacity(0.25)
-                  : Colors.black.withOpacity(0.05),
+                  ? AppColors.primary.withAlpha(25)
+                  : Colors.black.withAlpha(5),
               blurRadius: 10,
               offset: const Offset(2, 4),
               spreadRadius: 0,

--- a/lib/presentation/widgets/search_page/search_rooms_tile.dart
+++ b/lib/presentation/widgets/search_page/search_rooms_tile.dart
@@ -73,8 +73,8 @@ class _SearchRoomsTileState extends State<SearchRoomsTile> {
           boxShadow: [
             BoxShadow(
               color: _isPressed
-                  ? AppColors.primary.withOpacity(0.25)
-                  : Colors.black.withOpacity(0.05),
+                  ? AppColors.primary.withAlpha(25)
+                  : Colors.black.withAlpha(5),
               blurRadius: 10,
               offset: const Offset(2, 4),
               spreadRadius: 0,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -902,7 +902,7 @@ packages:
     source: hosted
     version: "1.1.19"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   flutter_compass: ^0.8.1
   flutter_blue_plus: ^1.32.9
   flutter_svg: ^2.2.3
+  vector_math: ^2.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📝작업 내용

> 길찾기 결과 화면
경로 선을 더 잘 보이게 변경(테두리, 화살표 추가)

> 길안내 화면
기존 정적 이미지에서 interactive viewer를 통해 확대/축소/이동할 수 있게 변경
경로 선 그래픽을 수정하고 사용자 위치에 동심원 이펙트를 추가
사용자 마커가 페이지 첫 번째 진입 시 제대로 초기화되지 않는 문제 해결
페이지 진입 이후 경로 검색을 끊임없이 하는 문제 해결
다른 건물을 오갈 경우 지도를 변경하는 기능 추가
출발 위치에 따라 보여주는 건물을 바꾸는 기능 추가
안내 종료 버튼 추가

> 기타
구버전 함수 경고 등등 잡다한 수정

❗주의사항
현재의 path_navi_page.dart의 UI 업데이트는 새로운 마커 이동 방식(정점-엣지 기반)을 고려하지 않고, 구 버전인 픽셀 좌표 이동에 대해 반영했습니다. 이유는 새로운 이동방식은 아직 develop과 합칠 수가 없어서..
나중에 현위치 추정 충돌 수정하고 나면 인공지능한테 보여주고 UI 이대로 고쳐달라고 하면 됩니다!

### 스크린샷 (선택)
|길찾기 미리보기|길안내|
|:--:|:--:|
|<img width="379" height="755" alt="스크린샷 2025-12-05 084944" src="https://github.com/user-attachments/assets/a6e34f3a-a368-4ecd-bca2-3f1ff2ca1088" />|<img width="380" height="837" alt="image" src="https://github.com/user-attachments/assets/545a8f3d-6f0f-45d5-880e-c463acb3abef" />|




